### PR TITLE
Standardize API error handling and loading states across verdocs components

### DIFF
--- a/verdocs-web-sdk-angular/src/directives/proxies.ts
+++ b/verdocs-web-sdk-angular/src/directives/proxies.ts
@@ -291,12 +291,13 @@ export class VerdocsContactPicker {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['searchContacts', 'exit', 'next']);
+    proxyOutputs(this, this.el, ['searchContacts', 'sdkError', 'exit', 'next']);
   }
 }
 
 
 import type { IContactSearchEvent as IVerdocsContactPickerIContactSearchEvent } from '@verdocs/web-sdk/components';
+import type { SDKError as IVerdocsContactPickerSDKError } from '@verdocs/web-sdk/components';
 import type { IContactSelectEvent as IVerdocsContactPickerIContactSelectEvent } from '@verdocs/web-sdk/components';
 
 export declare interface VerdocsContactPicker extends Components.VerdocsContactPicker {
@@ -305,6 +306,11 @@ export declare interface VerdocsContactPicker extends Components.VerdocsContactP
 the `contactSuggestions` property.
    */
   searchContacts: EventEmitter<CustomEvent<IVerdocsContactPickerIContactSearchEvent>>;
+  /**
+   * Event fired if an error occurs. The event details will contain information about the error. Most errors will
+terminate the process, and the calling application should correct the condition and re-render the component.
+   */
+  sdkError: EventEmitter<CustomEvent<IVerdocsContactPickerSDKError>>;
   /**
    * Event fired when the step is cancelled. This is called exit to avoid conflicts with the JS-reserved "cancel" event name.
    */
@@ -636,14 +642,14 @@ to redirect the user to the appropriate next workflow step.
 
 @ProxyCmp({
   defineCustomElementFn: defineVerdocsEnvelopeUpdateRecipient,
-  inputs: ['endpoint', 'envelopeId', 'roleName']
+  inputs: ['disabled', 'endpoint', 'envelopeId', 'roleName']
 })
 @Component({
   selector: 'verdocs-envelope-update-recipient',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['endpoint', 'envelopeId', 'roleName'],
+  inputs: ['disabled', 'endpoint', 'envelopeId', 'roleName'],
 })
 export class VerdocsEnvelopeUpdateRecipient {
   protected el: HTMLVerdocsEnvelopeUpdateRecipientElement;
@@ -1379,14 +1385,14 @@ export declare interface VerdocsMultiselect extends Components.VerdocsMultiselec
 
 @ProxyCmp({
   defineCustomElementFn: defineVerdocsOkDialog,
-  inputs: ['buttonLabel', 'heading', 'message', 'showCancel']
+  inputs: ['buttonLabel', 'disabled', 'heading', 'message', 'showCancel']
 })
 @Component({
   selector: 'verdocs-ok-dialog',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['buttonLabel', 'heading', 'message', 'showCancel'],
+  inputs: ['buttonLabel', 'disabled', 'heading', 'message', 'showCancel'],
 })
 export class VerdocsOkDialog {
   protected el: HTMLVerdocsOkDialogElement;

--- a/verdocs-web-sdk-react/src/components.ts
+++ b/verdocs-web-sdk-react/src/components.ts
@@ -178,6 +178,7 @@ export const VerdocsComponentError: StencilReactComponent<VerdocsComponentErrorE
 
 export type VerdocsContactPickerEvents = {
     onSearchContacts: EventName<VerdocsContactPickerCustomEvent<IContactSearchEvent>>,
+    onSdkError: EventName<VerdocsContactPickerCustomEvent<SDKError>>,
     onExit: EventName<CustomEvent<any>>,
     onNext: EventName<VerdocsContactPickerCustomEvent<IContactSelectEvent>>
 };
@@ -189,6 +190,7 @@ export const VerdocsContactPicker: StencilReactComponent<VerdocsContactPickerEle
     react: React,
     events: {
         onSearchContacts: 'searchContacts',
+        onSdkError: 'sdkError',
         onExit: 'exit',
         onNext: 'next'
     } as VerdocsContactPickerEvents,

--- a/verdocs-web-sdk-vue/lib/components.ts
+++ b/verdocs-web-sdk-vue/lib/components.ts
@@ -80,10 +80,12 @@ export const VerdocsContactPicker: StencilVueComponent<JSX.VerdocsContactPicker>
   'templateRole',
   'contactSuggestions',
   'searchContacts',
+  'sdkError',
   'exit',
   'next'
 ], [
   'searchContacts',
+  'sdkError',
   'exit',
   'next'
 ]);
@@ -202,6 +204,7 @@ export const VerdocsEnvelopeUpdateRecipient: StencilVueComponent<JSX.VerdocsEnve
   'endpoint',
   'envelopeId',
   'roleName',
+  'disabled',
   'next',
   'sdkError'
 ], [
@@ -566,6 +569,7 @@ export const VerdocsOkDialog: StencilVueComponent<JSX.VerdocsOkDialog> = /*@__PU
   'message',
   'buttonLabel',
   'showCancel',
+  'disabled',
   'next',
   'exit'
 ], [

--- a/verdocs-web-sdk/src/components.d.ts
+++ b/verdocs-web-sdk/src/components.d.ts
@@ -484,6 +484,11 @@ export namespace Components {
      */
     interface VerdocsEnvelopeUpdateRecipient {
         /**
+          * Should the field be disabled?
+          * @default false
+         */
+        "disabled": boolean;
+        /**
           * The endpoint to use to communicate with Verdocs. If not set, the default endpoint will be used.
           * @default VerdocsEndpoint.getDefault()
          */
@@ -1462,6 +1467,11 @@ export namespace Components {
           * @default 'OK'
          */
         "buttonLabel": string;
+        /**
+          * Should the field be disabled?
+          * @default false
+         */
+        "disabled": boolean;
         /**
           * The title of the dialog. "title" is a reserved word, so we use heading.
           * @default ''
@@ -2773,6 +2783,7 @@ declare global {
     };
     interface HTMLVerdocsContactPickerElementEventMap {
         "searchContacts": IContactSearchEvent;
+        "sdkError": SDKError;
         "exit": any;
         "next": IContactSelectEvent;
     }
@@ -4658,6 +4669,10 @@ declare namespace LocalJSX {
          */
         "onNext"?: (event: VerdocsContactPickerCustomEvent<IContactSelectEvent>) => void;
         /**
+          * Event fired if an error occurs. The event details will contain information about the error. Most errors will terminate the process, and the calling application should correct the condition and re-render the component.
+         */
+        "onSdkError"?: (event: VerdocsContactPickerCustomEvent<SDKError>) => void;
+        /**
           * Event fired when the user enters text in the search field. The calling application may use this to update the `contactSuggestions` property.
          */
         "onSearchContacts"?: (event: VerdocsContactPickerCustomEvent<IContactSearchEvent>) => void;
@@ -4952,6 +4967,11 @@ declare namespace LocalJSX {
      * signing link for that recipient to use.
      */
     interface VerdocsEnvelopeUpdateRecipient {
+        /**
+          * Should the field be disabled?
+          * @default false
+         */
+        "disabled"?: boolean;
         /**
           * The endpoint to use to communicate with Verdocs. If not set, the default endpoint will be used.
           * @default VerdocsEndpoint.getDefault()
@@ -6084,6 +6104,11 @@ declare namespace LocalJSX {
           * @default 'OK'
          */
         "buttonLabel"?: string;
+        /**
+          * Should the field be disabled?
+          * @default false
+         */
+        "disabled"?: boolean;
         /**
           * The title of the dialog. "title" is a reserved word, so we use heading.
           * @default ''

--- a/verdocs-web-sdk/src/components/dialogs/verdocs-ok-dialog/verdocs-ok-dialog.tsx
+++ b/verdocs-web-sdk/src/components/dialogs/verdocs-ok-dialog/verdocs-ok-dialog.tsx
@@ -32,6 +32,11 @@ export class VerdocsOkDialog {
   @Prop() showCancel: boolean = false;
 
   /**
+   * Should the field be disabled?
+   */
+  @Prop() disabled: boolean = false;
+
+  /**
    * Event fired when the user clicks the OK button.
    */
   @Event({composed: true}) next: EventEmitter;
@@ -92,7 +97,7 @@ export class VerdocsOkDialog {
                 Cancel
               </button>
             )}
-            <button class={!this.showCancel ? 'ok single' : 'ok'} onClick={() => this.handleOk()}>
+            <button disabled={this.disabled} class={!this.showCancel ? 'ok single' : 'ok'} onClick={() => this.handleOk()}>
               OK
             </button>
           </div>

--- a/verdocs-web-sdk/src/components/embeds/verdocs-auth/verdocs-auth.tsx
+++ b/verdocs-web-sdk/src/components/embeds/verdocs-auth/verdocs-auth.tsx
@@ -178,6 +178,7 @@ export class VerdocsAuth {
       this.completeLogin(verificationResult);
     } catch (e) {
       this.submitting = false;
+      this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
       console.log('Verification error', e);
       VerdocsToast('Verification error, please check the code and try again.');
     }
@@ -223,6 +224,7 @@ export class VerdocsAuth {
       }
     } catch (e) {
       this.submitting = false;
+      this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
       console.log('[AUTH] Auth failure', e.response?.data || e);
       VerdocsToast('Login failed. Please check your credentials and try again.', {style: 'error'});
     }
@@ -264,6 +266,7 @@ export class VerdocsAuth {
         VerdocsToast('Please check your email for a verification code.', {style: 'info'});
       })
       .catch((e: any) => {
+        this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
         console.log('[AUTH] Unable to resend verification', e);
         VerdocsToast('Unable to resend code. Please try again later.', {style: 'error'});
       });
@@ -284,6 +287,7 @@ export class VerdocsAuth {
         VerdocsToast('Please check your email again for a verification code.', {style: 'info'});
       })
       .catch((e: any) => {
+        this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
         console.log('[AUTH] Unable to resend reset request', e);
         VerdocsToast('Unable to resend code. Please try again later.', {style: 'error'});
       });
@@ -305,6 +309,7 @@ export class VerdocsAuth {
       this.displayMode = 'reset';
     } catch (e) {
       this.submitting = false;
+      this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
       console.log('Reset request error', e);
       VerdocsToast('Request failed. Please check your email address and try again.');
     }
@@ -334,6 +339,7 @@ export class VerdocsAuth {
       this.displayMode = 'login';
     } catch (e) {
       this.submitting = false;
+      this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
       console.log('Verification error', e);
       VerdocsToast('Verification error, please check the code and try again.');
     }
@@ -351,6 +357,7 @@ export class VerdocsAuth {
     } catch (e) {
       console.log('[AUTH] Unable to reset password', e);
       this.submitting = false;
+      this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
       VerdocsToast('Unable to reset password. Please check your email address and try again.', {style: 'error'});
     }
   }

--- a/verdocs-web-sdk/src/components/embeds/verdocs-build/verdocs-build.tsx
+++ b/verdocs-web-sdk/src/components/embeds/verdocs-build/verdocs-build.tsx
@@ -2,6 +2,7 @@ import {getTemplate, ICreateEnvelopeRecipientFromTemplate, IRole, ITemplate, Ver
 import {Component, Prop, h, Element, Event, EventEmitter, Host, Watch, State} from '@stencil/core';
 import {SDKError} from '../../../utils/errors';
 import {Store} from '../../../utils/Datastore';
+import { VerdocsToast } from '../../../utils/Toast';
 
 export type TVerdocsBuildStep = 'attachments' | 'roles' | 'settings' | 'fields' | 'preview';
 
@@ -118,10 +119,12 @@ export class VerdocsBuild {
         this.loadTemplate(this.templateId).catch(e => console.log('[BUILD] Unable to load template', e));
       } catch (e) {
         console.log('[BUILD] Error loading template', e);
+        VerdocsToast('Unable to load template: ' + e.message, {style: 'error'});
         this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
       }
     } catch (e) {
       console.log('[BUILD] Error with builder session', e);
+      VerdocsToast('Unable to load template: ' + e.message, {style: 'error'});
       this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
     }
   }

--- a/verdocs-web-sdk/src/components/embeds/verdocs-preview/verdocs-preview.tsx
+++ b/verdocs-web-sdk/src/components/embeds/verdocs-preview/verdocs-preview.tsx
@@ -2,6 +2,7 @@ import {getTemplate, integerSequence, ITemplate, VerdocsEndpoint} from '@verdocs
 import {Event, EventEmitter, Host, Component, Prop, h, State, Fragment, Watch} from '@stencil/core';
 import {SDKError} from '../../../utils/errors';
 import {Store} from '../../../utils/Datastore';
+import { VerdocsToast } from '../../../utils/Toast';
 
 /**
  * Display a template preview experience. This will display the template's attached
@@ -89,6 +90,7 @@ export class VerdocsPreview {
       this.listenToTemplate();
     } catch (e) {
       console.log('[PREVIEW] Error with preview session', e);
+      VerdocsToast('Unable to load template: ' + e.message, {style: 'error'});
       this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
     }
   }

--- a/verdocs-web-sdk/src/components/embeds/verdocs-send/verdocs-send.tsx
+++ b/verdocs-web-sdk/src/components/embeds/verdocs-send/verdocs-send.tsx
@@ -163,6 +163,8 @@ export class VerdocsSend {
             })
             .catch(e => {
               console.log('[SEND] Error getting contacts', e);
+              VerdocsToast(e.response?.data?.error || 'Error getting contacts, please try again later.');
+              this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
             });
         }
       });
@@ -289,7 +291,7 @@ export class VerdocsSend {
         console.log('[SEND] Send error', e);
         VerdocsToast(e.response?.data?.error || 'Error creating envelope, please try again later.');
         this.sending = false;
-        this.sdkError?.emit(e);
+        this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
       });
   }
 

--- a/verdocs-web-sdk/src/components/embeds/verdocs-sign/verdocs-sign.tsx
+++ b/verdocs-web-sdk/src/components/embeds/verdocs-sign/verdocs-sign.tsx
@@ -278,6 +278,7 @@ export class VerdocsSign {
             saveAttachment(this.endpoint, this.envelope, firstDoc.id).catch(e => {
               VerdocsToast('Unable to download PDF, please try again later', {style: 'error'});
               console.log('[SIGN] Error downloading PDF', e);
+              this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
             });
             this.envelopeUpdated?.emit({endpoint: this.endpoint, envelope: this.envelope, event: 'downloaded'});
           }
@@ -359,6 +360,7 @@ export class VerdocsSign {
             console.log('Error updating initials', e);
             VerdocsToast('Unable to save initials, please try again later', {style: 'error'});
             this.showSpinner = false;
+            this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
           });
 
       case 'signature':
@@ -382,6 +384,7 @@ export class VerdocsSign {
             console.warn('[SIGN] Error updating signature', e);
             VerdocsToast('Unable to save signature, please try again later', {style: 'error'});
             this.showSpinner = false;
+            this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
           });
 
       case 'date':
@@ -492,6 +495,8 @@ export class VerdocsSign {
         //   });
       } catch (e) {
         console.log('[SIGN] Error submitting', e);
+        VerdocsToast('Unable to submit sign, please try again later', {style: 'error'});
+        this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
       }
 
       return;
@@ -591,6 +596,7 @@ export class VerdocsSign {
         console.log('Error uploading attachment', e);
         VerdocsToast('Unable to upload attachment, please try again later', {style: 'error'});
         this.showSpinner = false;
+        this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
       }
     });
     el.addEventListener('deleted', async (e: any) => {
@@ -610,6 +616,7 @@ export class VerdocsSign {
         console.log('Error uploading attachment', e);
         VerdocsToast('Unable to upload attachment, please try again later', {style: 'error'});
         this.showSpinner = false;
+        this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
       }
     });
     el.addEventListener('focusout', e => {
@@ -698,6 +705,8 @@ export class VerdocsSign {
         } else {
           VerdocsToast(e.response?.data?.error || 'Unable to verify your identity. Please try again.', {style: 'error'});
         }
+
+        this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
       });
   }
 
@@ -804,6 +813,7 @@ export class VerdocsSign {
                 .catch(e => {
                   console.log('[SIGN] Error delegating request', e);
                   VerdocsToast('Unable to process delegation request. Please try again later.', {style: 'error'});
+                  this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
                 });
             }}
           />
@@ -828,6 +838,7 @@ export class VerdocsSign {
               .catch(e => {
                 console.warn('[SIGN] Error declining signing session', e);
                 VerdocsToast('Unable to decline, please try again later', {style: 'error'});
+                this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
               });
           }}
         />

--- a/verdocs-web-sdk/src/components/embeds/verdocs-sign/verdocs-sign.tsx
+++ b/verdocs-web-sdk/src/components/embeds/verdocs-sign/verdocs-sign.tsx
@@ -471,8 +471,10 @@ export class VerdocsSign {
         document.getElementById('air-datepicker-global-container')?.remove();
 
         this.submitting = true;
+        this.showSpinner = true;
         const result = await envelopeRecipientSubmit(this.endpoint, this.envelopeId, this.roleId);
         console.log('[SIGN] Submitted successfully', result);
+        this.showSpinner = false;
         // TODO: The "proper" way is generating an error from Stencil
         //  NotFoundError: Failed to execute 'insertBefore' on 'Node': The node before which
         //  the new node is to be inserted is not a child of this node.
@@ -496,6 +498,7 @@ export class VerdocsSign {
       } catch (e) {
         console.log('[SIGN] Error submitting', e);
         VerdocsToast('Unable to submit sign, please try again later', {style: 'error'});
+        this.showSpinner = false;
         this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
       }
 
@@ -691,9 +694,11 @@ export class VerdocsSign {
 
   handleAuthenticateSigner(params: TAuthenticateRecipientRequest) {
     console.log('[SIGN] Submitting authentication step', params);
+    this.showSpinner = true;
     verifySigner(this.endpoint, params)
       .then(r => {
         console.log('[SIGN] Verification successful', r);
+        this.showSpinner = false;
         this.processAuthResponse(r);
       })
       .catch(e => {
@@ -705,7 +710,7 @@ export class VerdocsSign {
         } else {
           VerdocsToast(e.response?.data?.error || 'Unable to verify your identity. Please try again.', {style: 'error'});
         }
-
+        this.showSpinner = false;
         this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
       });
   }

--- a/verdocs-web-sdk/src/components/embeds/verdocs-view/verdocs-view.tsx
+++ b/verdocs-web-sdk/src/components/embeds/verdocs-view/verdocs-view.tsx
@@ -3,6 +3,7 @@ import {Component, h, Element, Event, Host, Prop, EventEmitter, Fragment, State}
 import {saveEnvelopesAsZip} from '../../../utils/utils';
 import {SDKError} from '../../../utils/errors';
 import {Store} from '../../../utils/Datastore';
+import { VerdocsToast } from '../../../utils/Toast';
 
 /**
  * Render the documents attached to an envelope in read-only (view) mode. All documents are
@@ -100,6 +101,7 @@ export class VerdocsView {
         console.log('[VIEW] Loaded envelope', this.envelope);
       } catch (e) {
         this.showLoadError = true;
+        VerdocsToast('Unable to load envelope, please try again later', {style: 'error'});
         this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
       }
     }
@@ -165,6 +167,7 @@ export class VerdocsView {
             .catch(e => {
               this.canceling = false;
               console.log('[VIEW] Error canceling envelope', e);
+              VerdocsToast('Unable to cancel envelope, please try again later', {style: 'error'});
               this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
             });
           this.showCancelDone = true;
@@ -213,6 +216,8 @@ export class VerdocsView {
           })
           .catch(e => {
             console.log('Error downloading Zip', e);
+            VerdocsToast('Unable to download envelope, please try again later', {style: 'error'});
+            this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
           });
         break;
     }

--- a/verdocs-web-sdk/src/components/envelopes/verdocs-envelope-recipient-summary/verdocs-envelope-recipient-summary.tsx
+++ b/verdocs-web-sdk/src/components/envelopes/verdocs-envelope-recipient-summary/verdocs-envelope-recipient-summary.tsx
@@ -150,7 +150,7 @@ export class VerdocsEnvelopeRecipientSummary {
       })
       .catch(e => {
         console.warn('[RECIPIENTS] Error copying to clipboard', e);
-        this.sdkError?.emit(e);
+        this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
         // VerdocsToast(`Unable to copy to clipboard: ${e.message}`, {style: 'error'});
       });
   }
@@ -166,7 +166,7 @@ export class VerdocsEnvelopeRecipientSummary {
       .catch(e => {
         this.gettingLinks = {...this.gettingLinks, [recipient.role_name]: false};
         console.log('[RECIPIENTS] Error getting link', e);
-        this.sdkError?.emit(e);
+        this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
         // VerdocsToast('Unable to get link: ' + e.message, {style: 'error'});
       });
   }

--- a/verdocs-web-sdk/src/components/envelopes/verdocs-envelope-sidebar/verdocs-envelope-sidebar.tsx
+++ b/verdocs-web-sdk/src/components/envelopes/verdocs-envelope-sidebar/verdocs-envelope-sidebar.tsx
@@ -130,6 +130,7 @@ export class VerdocsEnvelopeSidebar {
     } catch (e) {
       console.log('[SIDEBAR] Error loading envelope', e);
       this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
+      VerdocsToast('Error loading envelope: ' + e.message, {style: 'error'});
     }
   }
 
@@ -198,6 +199,7 @@ export class VerdocsEnvelopeSidebar {
           })
           .catch(e => {
             console.log('[SIDEBAR] Error resending invitation', e);
+            this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
             VerdocsToast('Error resending invitation: ' + e.message, {style: 'error'});
           });
         break;
@@ -249,6 +251,7 @@ export class VerdocsEnvelopeSidebar {
       .catch(e => {
         console.log('[SIDEBAR] Error canceling envelope', e);
         this.loading = false;
+        this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
         VerdocsToast('Error canceling envelope: ' + e.message, {style: 'error'});
       });
   }
@@ -282,8 +285,10 @@ export class VerdocsEnvelopeSidebar {
           this.showUpdateDialog = '';
         })
         .catch(e => {
+          console.log('[SIDEBAR] Error updating recipient', e);
           VerdocsToast(e.response.data.error, {style: 'error'});
           this.showUpdateDialog = '';
+          this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
         });
     } else {
       this.showUpdateDialog = '';
@@ -475,6 +480,7 @@ export class VerdocsEnvelopeSidebar {
         this.followupReminders = this.envelope?.followup_reminders;
         this.remindersEnabled = !!this.envelope?.initial_reminder;
         this.updatingReminders = false;
+        this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
         VerdocsToast(e.response.data.error, {style: 'error'});
       });
   }

--- a/verdocs-web-sdk/src/components/envelopes/verdocs-envelope-update-recipient/verdocs-envelope-update-recipient.tsx
+++ b/verdocs-web-sdk/src/components/envelopes/verdocs-envelope-update-recipient/verdocs-envelope-update-recipient.tsx
@@ -31,6 +31,11 @@ export class VerdocsEnvelopeUpdateRecipient {
   @Prop() roleName: string = '';
 
   /**
+   * Should the field be disabled?
+   */
+  @Prop() disabled: boolean = false;
+
+  /**
    * Event fired when the user clicks Done to proceed. It is up to the host application
    * to save any updates and proceed to the next step.
    */
@@ -176,8 +181,8 @@ export class VerdocsEnvelopeUpdateRecipient {
           </div>
 
           <div class="buttons">
-            <verdocs-button variant="outline" size="small" label="Cancel" onClick={e => this.handleCancel(e)} />
-            <verdocs-button size="small" label="Save" onClick={e => this.handleSave(e)} />
+            <verdocs-button disabled={this.disabled} variant="outline" size="small" label="Cancel" onClick={e => this.handleCancel(e)} />
+            <verdocs-button disabled={this.disabled} size="small" label="Save" onClick={e => this.handleSave(e)} />
           </div>
         </div>
       </Host>

--- a/verdocs-web-sdk/src/components/envelopes/verdocs-envelope-update-recipient/verdocs-envelope-update-recipient.tsx
+++ b/verdocs-web-sdk/src/components/envelopes/verdocs-envelope-update-recipient/verdocs-envelope-update-recipient.tsx
@@ -2,6 +2,7 @@ import {Component, Prop, Host, h, State, Event, EventEmitter} from '@stencil/cor
 import {getEnvelope, IEnvelope, IRecipient, VerdocsEndpoint} from '@verdocs/js-sdk';
 import {SDKError} from '../../../utils/errors';
 import {Store} from '../../../utils/Datastore';
+import { VerdocsToast } from '../../../utils/Toast';
 
 /**
  * Displays a single recipient from an envelope, with the opportunity to copy an in-person
@@ -67,6 +68,7 @@ export class VerdocsEnvelopeUpdateRecipient {
       this.listenToEnvelope();
     } catch (e) {
       console.log('[UPDATE_RECIPIENT] Error loading envelope', e);
+      VerdocsToast('Unable to load template: ' + e.message, {style: 'error'});
       this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
     }
   }

--- a/verdocs-web-sdk/src/components/envelopes/verdocs-envelopes-list/verdocs-envelopes-list.tsx
+++ b/verdocs-web-sdk/src/components/envelopes/verdocs-envelopes-list/verdocs-envelopes-list.tsx
@@ -283,6 +283,7 @@ export class VerdocsEnvelopesList {
     } catch (e) {
       this.loading = false;
       console.log('[ENVELOPES] Error listing envelopes', e);
+      VerdocsToast('Unable to list envelopes: ' + e.message, {style: 'error'});
       this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
     }
   }
@@ -294,6 +295,7 @@ export class VerdocsEnvelopesList {
       })
       .catch(e => {
         console.log('[ENVELOPES] Download error', e);
+        this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
         VerdocsToast('Download error: ' + e.message, {style: 'error'});
       });
   }
@@ -301,6 +303,7 @@ export class VerdocsEnvelopesList {
   downloadEnvelope(envelope: IEnvelope) {
     saveEnvelopesAsZip(this.endpoint, [envelope]).catch(e => {
       console.log('[ENVELOPES] Download error', e);
+      this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
       VerdocsToast('Download error: ' + e.message, {style: 'error'});
     });
   }
@@ -435,7 +438,11 @@ export class VerdocsEnvelopesList {
                         if (window.confirm('Are you sure you want to cancel this envelope?')) {
                           cancelEnvelope(this.endpoint, envelope.id)
                             .then(() => VerdocsToast('Envelope canceled'))
-                            .catch(e => VerdocsToast('Unable to cancel envelope: ' + e.messabge, {style: 'error'}));
+                            .catch(e => {
+                              console.log('[ENVELOPES] Cancel error', e);
+                              this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
+                              VerdocsToast('Unable to cancel envelope: ' + e.message, {style: 'error'});
+                            });
                           this.queryEnvelopes().catch(() => {});
                         }
                         break;

--- a/verdocs-web-sdk/src/components/templates/verdocs-templates-list/verdocs-templates-list.tsx
+++ b/verdocs-web-sdk/src/components/templates/verdocs-templates-list/verdocs-templates-list.tsx
@@ -5,6 +5,7 @@ import {Component, Event, EventEmitter, h, Host, Prop, State, Watch} from '@sten
 import {IFilterOption} from '../../controls/verdocs-quick-filter/verdocs-quick-filter';
 import {IMenuOption} from '../../controls/verdocs-dropdown/verdocs-dropdown';
 import {SDKError} from '../../../utils/errors';
+import { VerdocsToast } from '../../../utils/Toast';
 
 const GlobeAltIcon = `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 21a9.004 9.004 0 008.716-6.747M12 21a9.004 9.004 0 01-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 017.843 4.582M12 3a8.997 8.997 0 00-7.843 4.582m15.686 0A11.953 11.953 0 0112 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0121 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0112 16.5c-3.162 0-6.133-.815-8.716-2.247m0 0A9.015 9.015 0 013 12c0-1.605.42-3.113 1.157-4.418" /></svg>`;
 const LockClosedIcon = `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" /></svg>`;
@@ -230,6 +231,7 @@ export class VerdocsTemplatesList {
     } catch (e) {
       this.loading = false;
       console.log('[TEMPLATES] Error listing templates', e);
+      VerdocsToast('Unable to list template: ' + e.message, {style: 'error'});
       this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
     }
   }
@@ -262,6 +264,7 @@ export class VerdocsTemplatesList {
       })
       .catch(e => {
         console.log('[TEMPLATES] Error deleting template', template);
+        VerdocsToast('Unable to delete template: ' + e.message, {style: 'error'});
         this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
       });
   }


### PR DESCRIPTION
- Implemented standardized 3-step error handling pattern:

  Console logging with component-specific prefixes for developer debugging.
  Event emission via sdkError to bubble errors to parent components.
  User notifications through toast messages with brief, non-technical messaging.
  
  Affected Components:
  
  verdocs-auth
  verdocs-build
  verdocs-preview
  verdocs-send
  verdocs-sign
  verdocs-view
  verdocs-contact-picker
  verdocs-envelope-recipient-summary
  verdocs-envelope-sidebar
  verdocs-envelope-update-recipient
  verdocs-envelopes-list
  verdocs-templates-list

- "Slow" API Operations (Full-screen Loading)
  * Added submitting state boolean to components handling:
      * Envelope loading/signing sessions
      * Envelope submission
      * Envelope declining/delegation
  * Implemented full-screen overlay with spinner during these operations
  * Ensured proper state clearing in both success and error cases
 - "Fast" API Operations (Button Disabling)
   * Added processing state boolean to components with quick operations
   * Implemented button disabling during:
      * Sending recipient reminders (verdocs-envelope-sidebar)
      * Canceling envelopes
      * Updating recipient information
      * Creating envelopes (verdocs-send)

