### PR TITLE
Fix web-sdk build targets for Vue and Angular, Add Vanilla JS target

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,16 @@ the required skeleton files for you in `src/components`. Move the folder created
   parent to provide some data, control, and business logic.
 - `embeds` - Embeds are fully functional "mini-apps". If provided with appropriate configurations (e.g API endpoints and authorization
   details) they can be used to represent entire experiences such as document preview, document signing, or search.
+
+
+
+## Specific Build Instructions
+> **For angular build target (verdocs-web-sdk-angular):** the NPM lib needs to be linked for local builds
+```bash
+cd verdocs-web-sdk
+npm run build && npm link
+
+cd ../verdocs-web-sdk-angular
+npm link @verdocs/web-sdk
+npm run build
+```

--- a/fix-angular-proxies.js
+++ b/fix-angular-proxies.js
@@ -17,10 +17,78 @@ if (fs.existsSync(proxiesPath)) {
   content = content.replace(/colHeaderClick: EventEmitter<CustomEvent<\{col: \[object Object\]\}>>;/g, 'colHeaderClick: EventEmitter<CustomEvent<{col: any}>>;');
   content = content.replace(/selectTab: EventEmitter<CustomEvent<\{tab: \[object Object\]; index: number\}>>;/g, 'selectTab: EventEmitter<CustomEvent<{tab: any; index: number}>>;');
 
-  // // Fix invalid or missing type names in proxies (from diagnostics)
-  // content = content.replace(/IVerdocsKbaDialogstring/g, 'any');
-  // content = content.replace(/IRecipient/g, 'any');
-  // content = content.replace(/IVerdocsKbaDialogIRecipient/g, 'any');
+  // Fix invalid or missing type names in proxies (from diagnostics)
+  content = content.replace(/IVerdocsKbaDialogstring/g, 'string');
+  // Only replace IRecipient when it's not already part of IVerdocsKbaDialogIRecipient
+  // Replace all IVerdocsKbaDialogIRecipient with IRecipient (since only IRecipient is exported)
+  content = content.replace(/IVerdocsKbaDialogIRecipient/g, 'IRecipient');
+  // Remove the import alias for IVerdocsKbaDialogIRecipient if present
+  content = content.replace(
+    /import type \{ IRecipient as IVerdocsKbaDialogIRecipient \} from '@verdocs\/web-sdk';\n?/g,
+    ''
+  );
+  // Ensure import for IRecipient exists
+  if (!content.includes("import type { IRecipient } from '@verdocs/web-sdk';")) {
+    content = content.replace(
+      /(import type \{[^\}]*)(\} from '@verdocs\/web-sdk';)/,
+      (match, p1, p2) => {
+        if (p1.includes('IRecipient')) return match;
+        return `${p1}, IRecipient${p2}`;
+      }
+    );
+  }
+
+  // Remove duplicate imports for IRecipient from '@verdocs/web-sdk'
+  const importLines = content.split('\n').filter(line =>
+    line.trim().startsWith("import type {") && line.includes("IRecipient") && line.includes("@verdocs/web-sdk")
+  );
+  if (importLines.length > 1) {
+    // Keep only the first occurrence
+    let firstFound = false;
+    content = content.split('\n').filter(line => {
+      if (
+        line.trim().startsWith("import type {") &&
+        line.includes("IRecipient") &&
+        line.includes("@verdocs/web-sdk")
+      ) {
+        if (!firstFound) {
+          firstFound = true;
+          return true;
+        }
+        return false;
+      }
+      return true;
+    }).join('\n');
+  }
+
+  // Replace all IVerdocsEnvelopeUpdateRecipientIRecipient with IRecipient
+  content = content.replace(/IVerdocsEnvelopeUpdateRecipientIRecipient/g, 'IRecipient');
+  // Remove the import alias for IVerdocsEnvelopeUpdateRecipientIRecipient if present
+  content = content.replace(
+    /import type \{ IRecipient as IVerdocsEnvelopeUpdateRecipientIRecipient \} from '@verdocs\/web-sdk';\n?/g,
+    ''
+  );
+  // Deduplicate IRecipient import again in case it was added
+  const iRecipientImportLines = content.split('\n').filter(line =>
+    line.trim().startsWith("import type {") && line.includes("IRecipient") && line.includes("@verdocs/web-sdk")
+  );
+  if (iRecipientImportLines.length > 1) {
+    let firstFound = false;
+    content = content.split('\n').filter(line => {
+      if (
+        line.trim().startsWith("import type {") &&
+        line.includes("IRecipient") &&
+        line.includes("@verdocs/web-sdk")
+      ) {
+        if (!firstFound) {
+          firstFound = true;
+          return true;
+        }
+        return false;
+      }
+      return true;
+    }).join('\n');
+  }
 
   fs.writeFileSync(proxiesPath, content, 'utf8');
 }

--- a/fix-angular-proxies.js
+++ b/fix-angular-proxies.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+
+const proxiesPath = path.join(__dirname, 'verdocs-web-sdk-angular', 'src', 'directives', 'proxies.ts');
+
+if (fs.existsSync(proxiesPath)) {
+  let content = fs.readFileSync(proxiesPath, 'utf8');
+  // Fix import path
+  content = content.replace(/from '@verdocs\/web-sdk\/dist\/components'/g, "from '@verdocs/web-sdk'");
+
+  // Fix invalid [object Object] type annotations in EventEmitter generics
+  // Replace {col: [object Object]} with {col: any}
+  content = content.replace(/CustomEvent<\{col: \[object Object\]\}>/g, 'CustomEvent<{col: any}>');
+  content = content.replace(/CustomEvent<\{tab: \[object Object\]; index: number\}>/g, 'CustomEvent<{tab: any; index: number}>');
+
+  // Also fix property signatures (not just EventEmitter instantiations)
+  content = content.replace(/colHeaderClick: EventEmitter<CustomEvent<\{col: \[object Object\]\}>>;/g, 'colHeaderClick: EventEmitter<CustomEvent<{col: any}>>;');
+  content = content.replace(/selectTab: EventEmitter<CustomEvent<\{tab: \[object Object\]; index: number\}>>;/g, 'selectTab: EventEmitter<CustomEvent<{tab: any; index: number}>>;');
+
+  // // Fix invalid or missing type names in proxies (from diagnostics)
+  // content = content.replace(/IVerdocsKbaDialogstring/g, 'any');
+  // content = content.replace(/IRecipient/g, 'any');
+  // content = content.replace(/IVerdocsKbaDialogIRecipient/g, 'any');
+
+  fs.writeFileSync(proxiesPath, content, 'utf8');
+}
+else{
+  console.error(`File not found: ${proxiesPath}`);
+}

--- a/verdocs-web-sdk-angular/.gitignore
+++ b/verdocs-web-sdk-angular/.gitignore
@@ -59,3 +59,5 @@ typings/
 
 # next.js build output
 .next
+
+build

--- a/verdocs-web-sdk-angular/package-lock.json
+++ b/verdocs-web-sdk-angular/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@angular/animations": "^19.2.14",
+        "@angular/compiler-cli": "^19.2.6",
         "@types/node": "^24.1.0",
         "fs-extra": "^11.3.0",
         "glob": "^11.0.3",
@@ -22,6 +23,20 @@
       },
       "peerDependencies": {
         "@angular/core": "^19.2.6"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@angular/animations": {
@@ -59,6 +74,49 @@
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
+    "node_modules/@angular/compiler": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-19.2.14.tgz",
+      "integrity": "sha512-ZqJDYOdhgKpVGNq3+n/Gbxma8DVYElDsoRe0tvNtjkWBVdaOxdZZUqmJ3kdCBsqD/aqTRvRBu0KGo9s2fCChkA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
+      }
+    },
+    "node_modules/@angular/compiler-cli": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-19.2.14.tgz",
+      "integrity": "sha512-e9/h86ETjoIK2yTLE9aUeMCKujdg/du2pq7run/aINjop4RtnNOw+ZlSTUa6R65lP5CVwDup1kPytpAoifw8cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "7.26.9",
+        "@jridgewell/sourcemap-codec": "^1.4.14",
+        "chokidar": "^4.0.0",
+        "convert-source-map": "^1.5.1",
+        "reflect-metadata": "^0.2.0",
+        "semver": "^7.0.0",
+        "tslib": "^2.3.0",
+        "yargs": "^17.2.1"
+      },
+      "bin": {
+        "ng-xi18n": "bundles/src/bin/ng_xi18n.js",
+        "ngc": "bundles/src/bin/ngc.js",
+        "ngcc": "bundles/ngcc/index.js"
+      },
+      "engines": {
+        "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
+      },
+      "peerDependencies": {
+        "@angular/compiler": "19.2.14",
+        "typescript": ">=5.5 <5.9"
+      }
+    },
     "node_modules/@angular/core": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-19.2.14.tgz",
@@ -76,6 +134,225 @@
         "zone.js": "~0.15.0"
       }
     },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz",
+      "integrity": "sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.9.tgz",
+      "integrity": "sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.26.2",
+        "@babel/generator": "^7.26.9",
+        "@babel/helper-compilation-targets": "^7.26.5",
+        "@babel/helper-module-transforms": "^7.26.0",
+        "@babel/helpers": "^7.26.9",
+        "@babel/parser": "^7.26.9",
+        "@babel/template": "^7.26.9",
+        "@babel/traverse": "^7.26.9",
+        "@babel/types": "^7.26.9",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
+      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.3",
+        "@babel/types": "^7.28.2",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
+      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.27.2",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
+      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/traverse": "^7.28.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.3.tgz",
+      "integrity": "sha512-PTNtvUQihsAsDHMOP5pfobP8C6CM4JWXmP8DrEIt46c3r2bf87Ua1zoqevsMo9g+tWDwgWrFP5EIxuBx5RudAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.3.tgz",
+      "integrity": "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@babel/polyfill": {
       "version": "7.12.1",
       "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
@@ -87,20 +364,61 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
-    "node_modules/@babel/polyfill/node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "license": "MIT"
-    },
     "node_modules/@babel/runtime-corejs3": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.27.0.tgz",
-      "integrity": "sha512-UWjX6t+v+0ckwZ50Y5ShZLnlk95pP5MyW/pon9tiYzl3+18pkTHTFNTKr7rQbfRXPkowt2QAn30o1b6oswszew==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.28.3.tgz",
+      "integrity": "sha512-LKYxD2CIfocUFNREQ1yk+dW+8OH8CRqmgatBZYXb+XhuObO8wsDpEoCNri5bKld9cnj8xukqZjxSX8p1YiRF8Q==",
       "license": "MIT",
       "dependencies": {
-        "core-js-pure": "^3.30.2",
-        "regenerator-runtime": "^0.14.0"
+        "core-js-pure": "^3.43.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.3.tgz",
+      "integrity": "sha512-7w4kZYHneL3A6NP2nxzHvT3HCZ7puDZZjFMqDpBPECub79sTtSO5CGXDkKrTQq8ksAwfD/XI2MRFX23njdDaIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.3",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.28.3",
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.2",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
+      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -236,6 +554,45 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.30",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz",
+      "integrity": "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@popperjs/core": {
@@ -465,9 +822,9 @@
       ]
     },
     "node_modules/@stencil/core": {
-      "version": "4.36.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.36.1.tgz",
-      "integrity": "sha512-LRZN1c4X+9/7kR+zG74SrcZ6XxKlilDTkDXajw3ioeDdVlJEvW5wU8Wn3BcAAnk7fjrgLZVN7ickgeuG7u0AKg==",
+      "version": "4.36.3",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.36.3.tgz",
+      "integrity": "sha512-C9DOaAjm+hSYRuVoUuYWG/lrYT8+4DG0AL0m1Ea9+G5v2Y6ApVpNJLbXvFlRZIdDMGecH86s6v0Gp39uockLxg==",
       "license": "MIT",
       "bin": {
         "stencil": "bin/stencil"
@@ -534,9 +891,9 @@
       }
     },
     "node_modules/@verdocs/js-sdk": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@verdocs/js-sdk/-/js-sdk-6.0.3.tgz",
-      "integrity": "sha512-kxtcW9CpdsYOK5AT+lB9ibPQa115Vj9HgKZVyGh8QwOWKKnJMhOFk2CquGci9IQGHorJhWuDPMDZLi0ISAkDkA==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@verdocs/js-sdk/-/js-sdk-6.0.5.tgz",
+      "integrity": "sha512-eSNNiTJyYQuGsCuNYTjsmxX1xoW3TQWi9CkUjDrz/vN1RpLmSWFIpuquKS3UHRYa+5Z0uidNoxDWS3drmBI8Lw==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.11.0"
@@ -615,6 +972,39 @@
         "proxy-from-env": "^1.1.0"
       }
     },
+    "node_modules/browserslist": {
+      "version": "4.25.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.3.tgz",
+      "integrity": "sha512-cDGv1kkDI4/0e5yON9yM5G/0A5u8sf5TnmdX5C9qHzI9PPu++sQ9zjm1k9NiOrf3riY4OkK0zSGqfvJyJsgCBQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001735",
+        "electron-to-chromium": "^1.5.204",
+        "node-releases": "^2.0.19",
+        "update-browserslist-db": "^1.1.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
     "node_modules/builtin-modules": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
@@ -641,6 +1031,27 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001737",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001737.tgz",
+      "integrity": "sha512-BiloLiXtQNrY5UyF0+1nSJLXUENuhka2pzy2Fx5pGxqavdrxSCW4U6Pn/PoG3Efspi2frRbHpBV2XsrPE6EDlw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
     "node_modules/choices.js": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/choices.js/-/choices.js-11.1.0.tgz",
@@ -648,6 +1059,37 @@
       "license": "MIT",
       "dependencies": {
         "fuse.js": "^7.0.0"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/color-convert": {
@@ -682,6 +1124,13 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/core-js": {
       "version": "2.6.12",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
@@ -691,9 +1140,9 @@
       "license": "MIT"
     },
     "node_modules/core-js-pure": {
-      "version": "3.41.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.41.0.tgz",
-      "integrity": "sha512-71Gzp96T9YPk63aUvE5Q5qP+DryB4ZloUZPSOebGM88VNw8VNfvdA7z6kGA8iGOTEzAomsRidp4jXSmUIJsL+Q==",
+      "version": "3.45.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.45.1.tgz",
+      "integrity": "sha512-OHnWFKgTUshEU8MK+lOs1H8kC8GkTi9Z1tvNkxrCcw9wl3MJIO7q2ld77wjWn4/xuGrVu2X+nME1iIIPBSdyEQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "funding": {
@@ -732,6 +1181,24 @@
         "url": "https://github.com/sponsors/kossnocorp"
       }
     },
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -761,6 +1228,13 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.208",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.208.tgz",
+      "integrity": "sha512-ozZyibehoe7tOhNaf16lKmljVf+3npZcJIEbJRVftVsmAg5TeA1mGS9dVCZzOwr2xT7xK15V0p7+GZqSPgkuPg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -812,6 +1286,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/estree-walker": {
@@ -933,6 +1417,26 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -1165,6 +1669,39 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -1197,6 +1734,16 @@
       "license": "MIT",
       "dependencies": {
         "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/math-intrinsics": {
@@ -1238,6 +1785,20 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
@@ -1296,6 +1857,13 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -1323,11 +1891,42 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
       "license": "MIT"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/resolve": {
       "version": "1.22.10",
@@ -1542,6 +2141,19 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
@@ -1658,17 +2270,17 @@
       }
     },
     "node_modules/tinybase": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/tinybase/-/tinybase-6.5.1.tgz",
-      "integrity": "sha512-/NDdP0jwD6kgzuhZpMhxDlH8st3AD3VmUh5ifIBUggec9QXCkorM/SQ3ggNZGv9SxjKGEilS7hpQzWVpNTmPRQ==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/tinybase/-/tinybase-6.5.2.tgz",
+      "integrity": "sha512-egWlEZSyG3+qhov+l/W6A/VgXQ28jHSfXpFr25UGVxdQB8Mn9qtJjC5Avey/QY0K7v4qAt1rJccSO0XQJ0Y93A==",
       "license": "MIT",
       "peerDependencies": {
         "@automerge/automerge-repo": "^1.2.1",
-        "@cloudflare/workers-types": "^4.20250806.0",
+        "@cloudflare/workers-types": "^4.20250813.0",
         "@electric-sql/pglite": "^0.2.17",
         "@libsql/client": "^0.15.10",
-        "@powersync/common": "^1.35.0",
-        "@sqlite.org/sqlite-wasm": "^3.50.3-build1",
+        "@powersync/common": "^1.36.0",
+        "@sqlite.org/sqlite-wasm": "^3.50.4-build1",
         "@vlcn.io/crsqlite-wasm": "^0.16.0",
         "bun": "^1.2.19",
         "electric-sql": "^0.12.1",
@@ -1787,6 +2399,37 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -1821,6 +2464,24 @@
         "@svgdotjs/svg.js": "^3.1.1"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
@@ -1838,6 +2499,52 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/zone.js": {

--- a/verdocs-web-sdk-angular/package.json
+++ b/verdocs-web-sdk-angular/package.json
@@ -30,8 +30,12 @@
   "peerDependencies": {
     "@angular/core": "^19.2.6"
   },
+  "dependencies": {
+    "@verdocs/web-sdk": "^6.0.4"
+  },
   "devDependencies": {
     "@angular/animations": "^19.2.14",
+    "@angular/compiler-cli": "^19.2.6",
     "@types/node": "^24.1.0",
     "fs-extra": "^11.3.0",
     "glob": "^11.0.3",

--- a/verdocs-web-sdk-angular/scripts/rollup.config.legacy.js
+++ b/verdocs-web-sdk-angular/scripts/rollup.config.legacy.js
@@ -1,4 +1,4 @@
-import config from './rollup.config';
+import config from './rollup.config.js';
 
 const newConfig = {
   ...config,

--- a/verdocs-web-sdk-angular/src/component-library-module.ts
+++ b/verdocs-web-sdk-angular/src/component-library-module.ts
@@ -1,18 +1,16 @@
 import { NgModule } from "@angular/core";
-import { defineCustomElements } from "component-library/loader";
-
-import { DemoComponent } from "./directives/proxies";
-
-defineCustomElements(window);
-
-const DECLARATIONS = [
-  // proxies
-  DemoComponent
-];
+/**
+ * NOTE: All proxy components are now Angular standalone components.
+ * Do NOT import or export them via an NgModule.
+ * Instead, import each proxy directly where needed:
+ *
+ * import { VerdocsAuth } from './directives/proxies';
+ *
+ * @see https://angular.io/guide/standalone-components
+ */
 
 @NgModule({
-  declarations: DECLARATIONS,
-  exports: DECLARATIONS,
+  // No declarations or exports needed for standalone proxies.
   imports: [],
   providers: []
 })

--- a/verdocs-web-sdk-angular/src/directives/proxies.ts
+++ b/verdocs-web-sdk-angular/src/directives/proxies.ts
@@ -4,7 +4,7 @@ import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, Even
 
 import { ProxyCmp } from './angular-component-lib/utils';
 
-import type { Components } from '@verdocs/web-sdk';
+import type { Components , IRecipient} from '@verdocs/web-sdk';
 
 import { defineCustomElement as defineVerdocsAuth } from '@verdocs/web-sdk/dist/components/verdocs-auth.js';
 import { defineCustomElement as defineVerdocsBuild } from '@verdocs/web-sdk/dist/components/verdocs-build.js';
@@ -678,7 +678,7 @@ to redirect the user to the appropriate next workflow step.
 })
 export class VerdocsEnvelopeUpdateRecipient {
   protected el: HTMLVerdocsEnvelopeUpdateRecipientElement;
-  @Output() next = new EventEmitter<CustomEvent<{action: 'cancel' | 'save'; originalRecipient: IVerdocsEnvelopeUpdateRecipientIRecipient; updatedRecipient: IVerdocsEnvelopeUpdateRecipientIRecipient}>>();
+  @Output() next = new EventEmitter<CustomEvent<{action: 'cancel' | 'save'; originalRecipient: IRecipient; updatedRecipient: IRecipient}>>();
   @Output() sdkError = new EventEmitter<CustomEvent<IVerdocsEnvelopeUpdateRecipientSDKError>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
@@ -687,7 +687,6 @@ export class VerdocsEnvelopeUpdateRecipient {
 }
 
 
-import type { IRecipient as IVerdocsEnvelopeUpdateRecipientIRecipient } from '@verdocs/web-sdk';
 import type { SDKError as IVerdocsEnvelopeUpdateRecipientSDKError } from '@verdocs/web-sdk';
 
 export declare interface VerdocsEnvelopeUpdateRecipient extends Components.VerdocsEnvelopeUpdateRecipient {
@@ -695,7 +694,7 @@ export declare interface VerdocsEnvelopeUpdateRecipient extends Components.Verdo
    * Event fired when the user clicks Done to proceed. It is up to the host application
 to save any updates and proceed to the next step.
    */
-  next: EventEmitter<CustomEvent<{action: 'cancel' | 'save'; originalRecipient: IVerdocsEnvelopeUpdateRecipientIRecipient; updatedRecipient: IVerdocsEnvelopeUpdateRecipientIRecipient}>>;
+  next: EventEmitter<CustomEvent<{action: 'cancel' | 'save'; originalRecipient: IRecipient; updatedRecipient: IRecipient}>>;
   /**
    * Event fired if an error occurs. The event details will contain information about the error. Most errors will
 terminate the process, and the calling application should correct the condition and re-render the component.
@@ -1348,8 +1347,8 @@ representation of the initials adopted.
 export class VerdocsKbaDialog {
   protected el: HTMLVerdocsKbaDialogElement;
   @Output() exit = new EventEmitter<CustomEvent<any>>();
-  @Output() pinEntered = new EventEmitter<CustomEvent<IVerdocsKbaDialogstring | IRecipient>>();
-  @Output() next = new EventEmitter<CustomEvent<IVerdocsKbaDialogstring | IVerdocsKbaDialogIRecipient | string[]>>();
+  @Output() pinEntered = new EventEmitter<CustomEvent<string | IRecipient>>();
+  @Output() next = new EventEmitter<CustomEvent<string | IRecipient | string[]>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
@@ -1357,7 +1356,6 @@ export class VerdocsKbaDialog {
 }
 
 
-import type { IRecipient as IVerdocsKbaDialogIRecipient } from '@verdocs/web-sdk';
 
 export declare interface VerdocsKbaDialog extends Components.VerdocsKbaDialog {
   /**
@@ -1368,12 +1366,12 @@ export declare interface VerdocsKbaDialog extends Components.VerdocsKbaDialog {
    * Event fired when the dialog is closed. The event data will contain the value selected,
 or the new recipient details if the mode is 'identity'.
    */
-  pinEntered: EventEmitter<CustomEvent<IVerdocsKbaDialogstring | IRecipient>>;
+  pinEntered: EventEmitter<CustomEvent<string | IRecipient>>;
   /**
    * Event fired when the dialog is closed. The event data will contain the value selected,
 or the new recipient details if the mode is 'identity'.
    */
-  next: EventEmitter<CustomEvent<IVerdocsKbaDialogstring | IVerdocsKbaDialogIRecipient | string[]>>;
+  next: EventEmitter<CustomEvent<string | IRecipient | string[]>>;
 }
 
 

--- a/verdocs-web-sdk-angular/src/directives/proxies.ts
+++ b/verdocs-web-sdk-angular/src/directives/proxies.ts
@@ -1,87 +1,87 @@
 /* tslint:disable */
 /* auto-generated angular directive proxies */
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, NgZone } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, Output, NgZone } from '@angular/core';
 
-import { ProxyCmp, proxyOutputs } from './angular-component-lib/utils';
+import { ProxyCmp } from './angular-component-lib/utils';
 
-import type { Components } from '@verdocs/web-sdk/components';
+import type { Components } from '@verdocs/web-sdk';
 
-import { defineCustomElement as defineVerdocsAuth } from '@verdocs/web-sdk/components/verdocs-auth.js';
-import { defineCustomElement as defineVerdocsBuild } from '@verdocs/web-sdk/components/verdocs-build.js';
-import { defineCustomElement as defineVerdocsButton } from '@verdocs/web-sdk/components/verdocs-button.js';
-import { defineCustomElement as defineVerdocsButtonPanel } from '@verdocs/web-sdk/components/verdocs-button-panel.js';
-import { defineCustomElement as defineVerdocsCheckbox } from '@verdocs/web-sdk/components/verdocs-checkbox.js';
-import { defineCustomElement as defineVerdocsComponentError } from '@verdocs/web-sdk/components/verdocs-component-error.js';
-import { defineCustomElement as defineVerdocsContactPicker } from '@verdocs/web-sdk/components/verdocs-contact-picker.js';
-import { defineCustomElement as defineVerdocsDateInput } from '@verdocs/web-sdk/components/verdocs-date-input.js';
-import { defineCustomElement as defineVerdocsDelegateDialog } from '@verdocs/web-sdk/components/verdocs-delegate-dialog.js';
-import { defineCustomElement as defineVerdocsDialog } from '@verdocs/web-sdk/components/verdocs-dialog.js';
-import { defineCustomElement as defineVerdocsDisclosureDialog } from '@verdocs/web-sdk/components/verdocs-disclosure-dialog.js';
-import { defineCustomElement as defineVerdocsDropdown } from '@verdocs/web-sdk/components/verdocs-dropdown.js';
-import { defineCustomElement as defineVerdocsEnvelopeDocumentPage } from '@verdocs/web-sdk/components/verdocs-envelope-document-page.js';
-import { defineCustomElement as defineVerdocsEnvelopeRecipientLink } from '@verdocs/web-sdk/components/verdocs-envelope-recipient-link.js';
-import { defineCustomElement as defineVerdocsEnvelopeRecipientSummary } from '@verdocs/web-sdk/components/verdocs-envelope-recipient-summary.js';
-import { defineCustomElement as defineVerdocsEnvelopeSidebar } from '@verdocs/web-sdk/components/verdocs-envelope-sidebar.js';
-import { defineCustomElement as defineVerdocsEnvelopeUpdateRecipient } from '@verdocs/web-sdk/components/verdocs-envelope-update-recipient.js';
-import { defineCustomElement as defineVerdocsEnvelopesList } from '@verdocs/web-sdk/components/verdocs-envelopes-list.js';
-import { defineCustomElement as defineVerdocsFieldAttachment } from '@verdocs/web-sdk/components/verdocs-field-attachment.js';
-import { defineCustomElement as defineVerdocsFieldCheckbox } from '@verdocs/web-sdk/components/verdocs-field-checkbox.js';
-import { defineCustomElement as defineVerdocsFieldDate } from '@verdocs/web-sdk/components/verdocs-field-date.js';
-import { defineCustomElement as defineVerdocsFieldDropdown } from '@verdocs/web-sdk/components/verdocs-field-dropdown.js';
-import { defineCustomElement as defineVerdocsFieldInitial } from '@verdocs/web-sdk/components/verdocs-field-initial.js';
-import { defineCustomElement as defineVerdocsFieldPayment } from '@verdocs/web-sdk/components/verdocs-field-payment.js';
-import { defineCustomElement as defineVerdocsFieldRadio } from '@verdocs/web-sdk/components/verdocs-field-radio.js';
-import { defineCustomElement as defineVerdocsFieldSignature } from '@verdocs/web-sdk/components/verdocs-field-signature.js';
-import { defineCustomElement as defineVerdocsFieldTextarea } from '@verdocs/web-sdk/components/verdocs-field-textarea.js';
-import { defineCustomElement as defineVerdocsFieldTextbox } from '@verdocs/web-sdk/components/verdocs-field-textbox.js';
-import { defineCustomElement as defineVerdocsFieldTimestamp } from '@verdocs/web-sdk/components/verdocs-field-timestamp.js';
-import { defineCustomElement as defineVerdocsFileChooser } from '@verdocs/web-sdk/components/verdocs-file-chooser.js';
-import { defineCustomElement as defineVerdocsHelpIcon } from '@verdocs/web-sdk/components/verdocs-help-icon.js';
-import { defineCustomElement as defineVerdocsInitialDialog } from '@verdocs/web-sdk/components/verdocs-initial-dialog.js';
-import { defineCustomElement as defineVerdocsKbaDialog } from '@verdocs/web-sdk/components/verdocs-kba-dialog.js';
-import { defineCustomElement as defineVerdocsLoader } from '@verdocs/web-sdk/components/verdocs-loader.js';
-import { defineCustomElement as defineVerdocsMenuPanel } from '@verdocs/web-sdk/components/verdocs-menu-panel.js';
-import { defineCustomElement as defineVerdocsMultiselect } from '@verdocs/web-sdk/components/verdocs-multiselect.js';
-import { defineCustomElement as defineVerdocsOkDialog } from '@verdocs/web-sdk/components/verdocs-ok-dialog.js';
-import { defineCustomElement as defineVerdocsOrganizationCard } from '@verdocs/web-sdk/components/verdocs-organization-card.js';
-import { defineCustomElement as defineVerdocsOtpDialog } from '@verdocs/web-sdk/components/verdocs-otp-dialog.js';
-import { defineCustomElement as defineVerdocsPagination } from '@verdocs/web-sdk/components/verdocs-pagination.js';
-import { defineCustomElement as defineVerdocsPortal } from '@verdocs/web-sdk/components/verdocs-portal.js';
-import { defineCustomElement as defineVerdocsPreview } from '@verdocs/web-sdk/components/verdocs-preview.js';
-import { defineCustomElement as defineVerdocsProgressBar } from '@verdocs/web-sdk/components/verdocs-progress-bar.js';
-import { defineCustomElement as defineVerdocsQuickFilter } from '@verdocs/web-sdk/components/verdocs-quick-filter.js';
-import { defineCustomElement as defineVerdocsQuickFunctions } from '@verdocs/web-sdk/components/verdocs-quick-functions.js';
-import { defineCustomElement as defineVerdocsRadioButton } from '@verdocs/web-sdk/components/verdocs-radio-button.js';
-import { defineCustomElement as defineVerdocsSearchBox } from '@verdocs/web-sdk/components/verdocs-search-box.js';
-import { defineCustomElement as defineVerdocsSearchTabs } from '@verdocs/web-sdk/components/verdocs-search-tabs.js';
-import { defineCustomElement as defineVerdocsSelectInput } from '@verdocs/web-sdk/components/verdocs-select-input.js';
-import { defineCustomElement as defineVerdocsSend } from '@verdocs/web-sdk/components/verdocs-send.js';
-import { defineCustomElement as defineVerdocsSign } from '@verdocs/web-sdk/components/verdocs-sign.js';
-import { defineCustomElement as defineVerdocsSignatureDialog } from '@verdocs/web-sdk/components/verdocs-signature-dialog.js';
-import { defineCustomElement as defineVerdocsSpinner } from '@verdocs/web-sdk/components/verdocs-spinner.js';
-import { defineCustomElement as defineVerdocsStatusIndicator } from '@verdocs/web-sdk/components/verdocs-status-indicator.js';
-import { defineCustomElement as defineVerdocsSwitch } from '@verdocs/web-sdk/components/verdocs-switch.js';
-import { defineCustomElement as defineVerdocsTable } from '@verdocs/web-sdk/components/verdocs-table.js';
-import { defineCustomElement as defineVerdocsTabs } from '@verdocs/web-sdk/components/verdocs-tabs.js';
-import { defineCustomElement as defineVerdocsTemplateAttachments } from '@verdocs/web-sdk/components/verdocs-template-attachments.js';
-import { defineCustomElement as defineVerdocsTemplateBuildTabs } from '@verdocs/web-sdk/components/verdocs-template-build-tabs.js';
-import { defineCustomElement as defineVerdocsTemplateCard } from '@verdocs/web-sdk/components/verdocs-template-card.js';
-import { defineCustomElement as defineVerdocsTemplateCreate } from '@verdocs/web-sdk/components/verdocs-template-create.js';
-import { defineCustomElement as defineVerdocsTemplateDocumentPage } from '@verdocs/web-sdk/components/verdocs-template-document-page.js';
-import { defineCustomElement as defineVerdocsTemplateFieldProperties } from '@verdocs/web-sdk/components/verdocs-template-field-properties.js';
-import { defineCustomElement as defineVerdocsTemplateFields } from '@verdocs/web-sdk/components/verdocs-template-fields.js';
-import { defineCustomElement as defineVerdocsTemplateRoleProperties } from '@verdocs/web-sdk/components/verdocs-template-role-properties.js';
-import { defineCustomElement as defineVerdocsTemplateRoles } from '@verdocs/web-sdk/components/verdocs-template-roles.js';
-import { defineCustomElement as defineVerdocsTemplateSettings } from '@verdocs/web-sdk/components/verdocs-template-settings.js';
-import { defineCustomElement as defineVerdocsTemplateStar } from '@verdocs/web-sdk/components/verdocs-template-star.js';
-import { defineCustomElement as defineVerdocsTemplateTags } from '@verdocs/web-sdk/components/verdocs-template-tags.js';
-import { defineCustomElement as defineVerdocsTemplatesList } from '@verdocs/web-sdk/components/verdocs-templates-list.js';
-import { defineCustomElement as defineVerdocsTextInput } from '@verdocs/web-sdk/components/verdocs-text-input.js';
-import { defineCustomElement as defineVerdocsToggle } from '@verdocs/web-sdk/components/verdocs-toggle.js';
-import { defineCustomElement as defineVerdocsToggleButton } from '@verdocs/web-sdk/components/verdocs-toggle-button.js';
-import { defineCustomElement as defineVerdocsToolbarIcon } from '@verdocs/web-sdk/components/verdocs-toolbar-icon.js';
-import { defineCustomElement as defineVerdocsUploadDialog } from '@verdocs/web-sdk/components/verdocs-upload-dialog.js';
-import { defineCustomElement as defineVerdocsView } from '@verdocs/web-sdk/components/verdocs-view.js';
+import { defineCustomElement as defineVerdocsAuth } from '@verdocs/web-sdk/dist/components/verdocs-auth.js';
+import { defineCustomElement as defineVerdocsBuild } from '@verdocs/web-sdk/dist/components/verdocs-build.js';
+import { defineCustomElement as defineVerdocsButton } from '@verdocs/web-sdk/dist/components/verdocs-button.js';
+import { defineCustomElement as defineVerdocsButtonPanel } from '@verdocs/web-sdk/dist/components/verdocs-button-panel.js';
+import { defineCustomElement as defineVerdocsCheckbox } from '@verdocs/web-sdk/dist/components/verdocs-checkbox.js';
+import { defineCustomElement as defineVerdocsComponentError } from '@verdocs/web-sdk/dist/components/verdocs-component-error.js';
+import { defineCustomElement as defineVerdocsContactPicker } from '@verdocs/web-sdk/dist/components/verdocs-contact-picker.js';
+import { defineCustomElement as defineVerdocsDateInput } from '@verdocs/web-sdk/dist/components/verdocs-date-input.js';
+import { defineCustomElement as defineVerdocsDelegateDialog } from '@verdocs/web-sdk/dist/components/verdocs-delegate-dialog.js';
+import { defineCustomElement as defineVerdocsDialog } from '@verdocs/web-sdk/dist/components/verdocs-dialog.js';
+import { defineCustomElement as defineVerdocsDisclosureDialog } from '@verdocs/web-sdk/dist/components/verdocs-disclosure-dialog.js';
+import { defineCustomElement as defineVerdocsDropdown } from '@verdocs/web-sdk/dist/components/verdocs-dropdown.js';
+import { defineCustomElement as defineVerdocsEnvelopeDocumentPage } from '@verdocs/web-sdk/dist/components/verdocs-envelope-document-page.js';
+import { defineCustomElement as defineVerdocsEnvelopeRecipientLink } from '@verdocs/web-sdk/dist/components/verdocs-envelope-recipient-link.js';
+import { defineCustomElement as defineVerdocsEnvelopeRecipientSummary } from '@verdocs/web-sdk/dist/components/verdocs-envelope-recipient-summary.js';
+import { defineCustomElement as defineVerdocsEnvelopeSidebar } from '@verdocs/web-sdk/dist/components/verdocs-envelope-sidebar.js';
+import { defineCustomElement as defineVerdocsEnvelopeUpdateRecipient } from '@verdocs/web-sdk/dist/components/verdocs-envelope-update-recipient.js';
+import { defineCustomElement as defineVerdocsEnvelopesList } from '@verdocs/web-sdk/dist/components/verdocs-envelopes-list.js';
+import { defineCustomElement as defineVerdocsFieldAttachment } from '@verdocs/web-sdk/dist/components/verdocs-field-attachment.js';
+import { defineCustomElement as defineVerdocsFieldCheckbox } from '@verdocs/web-sdk/dist/components/verdocs-field-checkbox.js';
+import { defineCustomElement as defineVerdocsFieldDate } from '@verdocs/web-sdk/dist/components/verdocs-field-date.js';
+import { defineCustomElement as defineVerdocsFieldDropdown } from '@verdocs/web-sdk/dist/components/verdocs-field-dropdown.js';
+import { defineCustomElement as defineVerdocsFieldInitial } from '@verdocs/web-sdk/dist/components/verdocs-field-initial.js';
+import { defineCustomElement as defineVerdocsFieldPayment } from '@verdocs/web-sdk/dist/components/verdocs-field-payment.js';
+import { defineCustomElement as defineVerdocsFieldRadio } from '@verdocs/web-sdk/dist/components/verdocs-field-radio.js';
+import { defineCustomElement as defineVerdocsFieldSignature } from '@verdocs/web-sdk/dist/components/verdocs-field-signature.js';
+import { defineCustomElement as defineVerdocsFieldTextarea } from '@verdocs/web-sdk/dist/components/verdocs-field-textarea.js';
+import { defineCustomElement as defineVerdocsFieldTextbox } from '@verdocs/web-sdk/dist/components/verdocs-field-textbox.js';
+import { defineCustomElement as defineVerdocsFieldTimestamp } from '@verdocs/web-sdk/dist/components/verdocs-field-timestamp.js';
+import { defineCustomElement as defineVerdocsFileChooser } from '@verdocs/web-sdk/dist/components/verdocs-file-chooser.js';
+import { defineCustomElement as defineVerdocsHelpIcon } from '@verdocs/web-sdk/dist/components/verdocs-help-icon.js';
+import { defineCustomElement as defineVerdocsInitialDialog } from '@verdocs/web-sdk/dist/components/verdocs-initial-dialog.js';
+import { defineCustomElement as defineVerdocsKbaDialog } from '@verdocs/web-sdk/dist/components/verdocs-kba-dialog.js';
+import { defineCustomElement as defineVerdocsLoader } from '@verdocs/web-sdk/dist/components/verdocs-loader.js';
+import { defineCustomElement as defineVerdocsMenuPanel } from '@verdocs/web-sdk/dist/components/verdocs-menu-panel.js';
+import { defineCustomElement as defineVerdocsMultiselect } from '@verdocs/web-sdk/dist/components/verdocs-multiselect.js';
+import { defineCustomElement as defineVerdocsOkDialog } from '@verdocs/web-sdk/dist/components/verdocs-ok-dialog.js';
+import { defineCustomElement as defineVerdocsOrganizationCard } from '@verdocs/web-sdk/dist/components/verdocs-organization-card.js';
+import { defineCustomElement as defineVerdocsOtpDialog } from '@verdocs/web-sdk/dist/components/verdocs-otp-dialog.js';
+import { defineCustomElement as defineVerdocsPagination } from '@verdocs/web-sdk/dist/components/verdocs-pagination.js';
+import { defineCustomElement as defineVerdocsPortal } from '@verdocs/web-sdk/dist/components/verdocs-portal.js';
+import { defineCustomElement as defineVerdocsPreview } from '@verdocs/web-sdk/dist/components/verdocs-preview.js';
+import { defineCustomElement as defineVerdocsProgressBar } from '@verdocs/web-sdk/dist/components/verdocs-progress-bar.js';
+import { defineCustomElement as defineVerdocsQuickFilter } from '@verdocs/web-sdk/dist/components/verdocs-quick-filter.js';
+import { defineCustomElement as defineVerdocsQuickFunctions } from '@verdocs/web-sdk/dist/components/verdocs-quick-functions.js';
+import { defineCustomElement as defineVerdocsRadioButton } from '@verdocs/web-sdk/dist/components/verdocs-radio-button.js';
+import { defineCustomElement as defineVerdocsSearchBox } from '@verdocs/web-sdk/dist/components/verdocs-search-box.js';
+import { defineCustomElement as defineVerdocsSearchTabs } from '@verdocs/web-sdk/dist/components/verdocs-search-tabs.js';
+import { defineCustomElement as defineVerdocsSelectInput } from '@verdocs/web-sdk/dist/components/verdocs-select-input.js';
+import { defineCustomElement as defineVerdocsSend } from '@verdocs/web-sdk/dist/components/verdocs-send.js';
+import { defineCustomElement as defineVerdocsSign } from '@verdocs/web-sdk/dist/components/verdocs-sign.js';
+import { defineCustomElement as defineVerdocsSignatureDialog } from '@verdocs/web-sdk/dist/components/verdocs-signature-dialog.js';
+import { defineCustomElement as defineVerdocsSpinner } from '@verdocs/web-sdk/dist/components/verdocs-spinner.js';
+import { defineCustomElement as defineVerdocsStatusIndicator } from '@verdocs/web-sdk/dist/components/verdocs-status-indicator.js';
+import { defineCustomElement as defineVerdocsSwitch } from '@verdocs/web-sdk/dist/components/verdocs-switch.js';
+import { defineCustomElement as defineVerdocsTable } from '@verdocs/web-sdk/dist/components/verdocs-table.js';
+import { defineCustomElement as defineVerdocsTabs } from '@verdocs/web-sdk/dist/components/verdocs-tabs.js';
+import { defineCustomElement as defineVerdocsTemplateAttachments } from '@verdocs/web-sdk/dist/components/verdocs-template-attachments.js';
+import { defineCustomElement as defineVerdocsTemplateBuildTabs } from '@verdocs/web-sdk/dist/components/verdocs-template-build-tabs.js';
+import { defineCustomElement as defineVerdocsTemplateCard } from '@verdocs/web-sdk/dist/components/verdocs-template-card.js';
+import { defineCustomElement as defineVerdocsTemplateCreate } from '@verdocs/web-sdk/dist/components/verdocs-template-create.js';
+import { defineCustomElement as defineVerdocsTemplateDocumentPage } from '@verdocs/web-sdk/dist/components/verdocs-template-document-page.js';
+import { defineCustomElement as defineVerdocsTemplateFieldProperties } from '@verdocs/web-sdk/dist/components/verdocs-template-field-properties.js';
+import { defineCustomElement as defineVerdocsTemplateFields } from '@verdocs/web-sdk/dist/components/verdocs-template-fields.js';
+import { defineCustomElement as defineVerdocsTemplateRoleProperties } from '@verdocs/web-sdk/dist/components/verdocs-template-role-properties.js';
+import { defineCustomElement as defineVerdocsTemplateRoles } from '@verdocs/web-sdk/dist/components/verdocs-template-roles.js';
+import { defineCustomElement as defineVerdocsTemplateSettings } from '@verdocs/web-sdk/dist/components/verdocs-template-settings.js';
+import { defineCustomElement as defineVerdocsTemplateStar } from '@verdocs/web-sdk/dist/components/verdocs-template-star.js';
+import { defineCustomElement as defineVerdocsTemplateTags } from '@verdocs/web-sdk/dist/components/verdocs-template-tags.js';
+import { defineCustomElement as defineVerdocsTemplatesList } from '@verdocs/web-sdk/dist/components/verdocs-templates-list.js';
+import { defineCustomElement as defineVerdocsTextInput } from '@verdocs/web-sdk/dist/components/verdocs-text-input.js';
+import { defineCustomElement as defineVerdocsToggle } from '@verdocs/web-sdk/dist/components/verdocs-toggle.js';
+import { defineCustomElement as defineVerdocsToggleButton } from '@verdocs/web-sdk/dist/components/verdocs-toggle-button.js';
+import { defineCustomElement as defineVerdocsToolbarIcon } from '@verdocs/web-sdk/dist/components/verdocs-toolbar-icon.js';
+import { defineCustomElement as defineVerdocsUploadDialog } from '@verdocs/web-sdk/dist/components/verdocs-upload-dialog.js';
+import { defineCustomElement as defineVerdocsView } from '@verdocs/web-sdk/dist/components/verdocs-view.js';
 @ProxyCmp({
   defineCustomElementFn: defineVerdocsAuth,
   inputs: ['displayMode', 'endpoint', 'logo', 'visible']
@@ -92,19 +92,21 @@ import { defineCustomElement as defineVerdocsView } from '@verdocs/web-sdk/compo
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['displayMode', 'endpoint', 'logo', 'visible'],
+  outputs: ['authenticated', 'sdkError'],
 })
 export class VerdocsAuth {
   protected el: HTMLVerdocsAuthElement;
+  @Output() authenticated = new EventEmitter<CustomEvent<IVerdocsAuthIAuthStatus>>();
+  @Output() sdkError = new EventEmitter<CustomEvent<IVerdocsAuthSDKError>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['authenticated', 'sdkError']);
   }
 }
 
 
-import type { IAuthStatus as IVerdocsAuthIAuthStatus } from '@verdocs/web-sdk/components';
-import type { SDKError as IVerdocsAuthSDKError } from '@verdocs/web-sdk/components';
+import type { IAuthStatus as IVerdocsAuthIAuthStatus } from '@verdocs/web-sdk';
+import type { SDKError as IVerdocsAuthSDKError } from '@verdocs/web-sdk';
 
 export declare interface VerdocsAuth extends Components.VerdocsAuth {
   /**
@@ -131,23 +133,30 @@ terminate the process, and the calling application should correct the condition 
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['endpoint', 'step', 'templateId'],
+  outputs: ['cancel', 'sdkError', 'stepChanged', 'send', 'templateUpdated', 'templateCreated', 'rolesUpdated'],
 })
 export class VerdocsBuild {
   protected el: HTMLVerdocsBuildElement;
+  @Output() cancel = new EventEmitter<CustomEvent<any>>();
+  @Output() sdkError = new EventEmitter<CustomEvent<IVerdocsBuildSDKError>>();
+  @Output() stepChanged = new EventEmitter<CustomEvent<IVerdocsBuildTVerdocsBuildStep>>();
+  @Output() send = new EventEmitter<CustomEvent<{recipients: IVerdocsBuildICreateEnvelopeRecipientFromTemplate[]; name: string; template_id: string}>>();
+  @Output() templateUpdated = new EventEmitter<CustomEvent<{endpoint: IVerdocsBuildVerdocsEndpoint; template: IVerdocsBuildITemplate; event: string}>>();
+  @Output() templateCreated = new EventEmitter<CustomEvent<{endpoint: IVerdocsBuildVerdocsEndpoint; template: IVerdocsBuildITemplate; event: string}>>();
+  @Output() rolesUpdated = new EventEmitter<CustomEvent<{endpoint: IVerdocsBuildVerdocsEndpoint; templateId: string; event: 'added' | 'deleted' | 'updated'; roles: IVerdocsBuildIRole[]}>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['cancel', 'sdkError', 'stepChanged', 'send', 'templateUpdated', 'templateCreated', 'rolesUpdated']);
   }
 }
 
 
-import type { SDKError as IVerdocsBuildSDKError } from '@verdocs/web-sdk/components';
-import type { TVerdocsBuildStep as IVerdocsBuildTVerdocsBuildStep } from '@verdocs/web-sdk/components';
-import type { ICreateEnvelopeRecipientFromTemplate as IVerdocsBuildICreateEnvelopeRecipientFromTemplate } from '@verdocs/web-sdk/components';
-import type { VerdocsEndpoint as IVerdocsBuildVerdocsEndpoint } from '@verdocs/web-sdk/components';
-import type { ITemplate as IVerdocsBuildITemplate } from '@verdocs/web-sdk/components';
-import type { IRole as IVerdocsBuildIRole } from '@verdocs/web-sdk/components';
+import type { SDKError as IVerdocsBuildSDKError } from '@verdocs/web-sdk';
+import type { TVerdocsBuildStep as IVerdocsBuildTVerdocsBuildStep } from '@verdocs/web-sdk';
+import type { ICreateEnvelopeRecipientFromTemplate as IVerdocsBuildICreateEnvelopeRecipientFromTemplate } from '@verdocs/web-sdk';
+import type { VerdocsEndpoint as IVerdocsBuildVerdocsEndpoint } from '@verdocs/web-sdk';
+import type { ITemplate as IVerdocsBuildITemplate } from '@verdocs/web-sdk';
+import type { IRole as IVerdocsBuildIRole } from '@verdocs/web-sdk';
 
 export declare interface VerdocsBuild extends Components.VerdocsBuild {
   /**
@@ -285,19 +294,22 @@ export declare interface VerdocsComponentError extends Components.VerdocsCompone
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['contactSuggestions', 'endpoint', 'templateRole'],
+  outputs: ['searchContacts', 'exit', 'next'],
 })
 export class VerdocsContactPicker {
   protected el: HTMLVerdocsContactPickerElement;
+  @Output() searchContacts = new EventEmitter<CustomEvent<IVerdocsContactPickerIContactSearchEvent>>();
+  @Output() exit = new EventEmitter<CustomEvent<any>>();
+  @Output() next = new EventEmitter<CustomEvent<IVerdocsContactPickerIContactSelectEvent>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['searchContacts', 'exit', 'next']);
   }
 }
 
 
-import type { IContactSearchEvent as IVerdocsContactPickerIContactSearchEvent } from '@verdocs/web-sdk/components';
-import type { IContactSelectEvent as IVerdocsContactPickerIContactSelectEvent } from '@verdocs/web-sdk/components';
+import type { IContactSearchEvent as IVerdocsContactPickerIContactSearchEvent } from '@verdocs/web-sdk';
+import type { IContactSelectEvent as IVerdocsContactPickerIContactSelectEvent } from '@verdocs/web-sdk';
 
 export declare interface VerdocsContactPicker extends Components.VerdocsContactPicker {
   /**
@@ -350,13 +362,15 @@ export declare interface VerdocsDateInput extends Components.VerdocsDateInput {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['endpoint', 'envelope'],
+  outputs: ['exit', 'next'],
 })
 export class VerdocsDelegateDialog {
   protected el: HTMLVerdocsDelegateDialogElement;
+  @Output() exit = new EventEmitter<CustomEvent<any>>();
+  @Output() next = new EventEmitter<CustomEvent<{first_name: string; last_name: string; email: string; phone: string; message: string}>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['exit', 'next']);
   }
 }
 
@@ -382,13 +396,14 @@ export declare interface VerdocsDelegateDialog extends Components.VerdocsDelegat
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: [],
+  outputs: ['exit'],
 })
 export class VerdocsDialog {
   protected el: HTMLVerdocsDialogElement;
+  @Output() exit = new EventEmitter<CustomEvent<any>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['exit']);
   }
 }
 
@@ -411,13 +426,16 @@ export declare interface VerdocsDialog extends Components.VerdocsDialog {
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['delegator', 'disclosures'],
+  outputs: ['decline', 'delegate', 'accept'],
 })
 export class VerdocsDisclosureDialog {
   protected el: HTMLVerdocsDisclosureDialogElement;
+  @Output() decline = new EventEmitter<CustomEvent<{first_name: string; last_name: string; email: string; phone: string; message: string}>>();
+  @Output() delegate = new EventEmitter<CustomEvent<{first_name: string; last_name: string; email: string; phone: string; message: string}>>();
+  @Output() accept = new EventEmitter<CustomEvent<{first_name: string; last_name: string; email: string; phone: string; message: string}>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['decline', 'delegate', 'accept']);
   }
 }
 
@@ -448,18 +466,19 @@ export declare interface VerdocsDisclosureDialog extends Components.VerdocsDiscl
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['options'],
+  outputs: ['optionSelected'],
 })
 export class VerdocsDropdown {
   protected el: HTMLVerdocsDropdownElement;
+  @Output() optionSelected = new EventEmitter<CustomEvent<IVerdocsDropdownIMenuOption>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['optionSelected']);
   }
 }
 
 
-import type { IMenuOption as IVerdocsDropdownIMenuOption } from '@verdocs/web-sdk/components';
+import type { IMenuOption as IVerdocsDropdownIMenuOption } from '@verdocs/web-sdk';
 
 export declare interface VerdocsDropdown extends Components.VerdocsDropdown {
   /**
@@ -480,18 +499,19 @@ Web Component events need to be "composed" to cross the Shadow DOM and be receiv
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['documentId', 'endpoint', 'envelopeId', 'layers', 'pageNumber', 'type', 'virtualHeight', 'virtualWidth'],
+  outputs: ['pageRendered'],
 })
 export class VerdocsEnvelopeDocumentPage {
   protected el: HTMLVerdocsEnvelopeDocumentPageElement;
+  @Output() pageRendered = new EventEmitter<CustomEvent<IVerdocsEnvelopeDocumentPageIDocumentPageInfo>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['pageRendered']);
   }
 }
 
 
-import type { IDocumentPageInfo as IVerdocsEnvelopeDocumentPageIDocumentPageInfo } from '@verdocs/web-sdk/components';
+import type { IDocumentPageInfo as IVerdocsEnvelopeDocumentPageIDocumentPageInfo } from '@verdocs/web-sdk';
 
 export declare interface VerdocsEnvelopeDocumentPage extends Components.VerdocsEnvelopeDocumentPage {
   /**
@@ -511,19 +531,21 @@ export declare interface VerdocsEnvelopeDocumentPage extends Components.VerdocsE
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['endpoint', 'envelopeId', 'roleName'],
+  outputs: ['next', 'sdkError'],
 })
 export class VerdocsEnvelopeRecipientLink {
   protected el: HTMLVerdocsEnvelopeRecipientLinkElement;
+  @Output() next = new EventEmitter<CustomEvent<{envelope: IVerdocsEnvelopeRecipientLinkIEnvelope}>>();
+  @Output() sdkError = new EventEmitter<CustomEvent<IVerdocsEnvelopeRecipientLinkSDKError>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['next', 'sdkError']);
   }
 }
 
 
-import type { IEnvelope as IVerdocsEnvelopeRecipientLinkIEnvelope } from '@verdocs/web-sdk/components';
-import type { SDKError as IVerdocsEnvelopeRecipientLinkSDKError } from '@verdocs/web-sdk/components';
+import type { IEnvelope as IVerdocsEnvelopeRecipientLinkIEnvelope } from '@verdocs/web-sdk';
+import type { SDKError as IVerdocsEnvelopeRecipientLinkSDKError } from '@verdocs/web-sdk';
 
 export declare interface VerdocsEnvelopeRecipientLink extends Components.VerdocsEnvelopeRecipientLink {
   /**
@@ -549,19 +571,23 @@ terminate the process, and the calling application should correct the condition 
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['canDone', 'canSendAnother', 'canView', 'endpoint', 'envelopeId'],
+  outputs: ['another', 'view', 'next', 'sdkError'],
 })
 export class VerdocsEnvelopeRecipientSummary {
   protected el: HTMLVerdocsEnvelopeRecipientSummaryElement;
+  @Output() another = new EventEmitter<CustomEvent<{envelope: IVerdocsEnvelopeRecipientSummaryIEnvelope}>>();
+  @Output() view = new EventEmitter<CustomEvent<{envelope: IVerdocsEnvelopeRecipientSummaryIEnvelope}>>();
+  @Output() next = new EventEmitter<CustomEvent<{envelope: IVerdocsEnvelopeRecipientSummaryIEnvelope}>>();
+  @Output() sdkError = new EventEmitter<CustomEvent<IVerdocsEnvelopeRecipientSummarySDKError>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['another', 'view', 'next', 'sdkError']);
   }
 }
 
 
-import type { IEnvelope as IVerdocsEnvelopeRecipientSummaryIEnvelope } from '@verdocs/web-sdk/components';
-import type { SDKError as IVerdocsEnvelopeRecipientSummarySDKError } from '@verdocs/web-sdk/components';
+import type { IEnvelope as IVerdocsEnvelopeRecipientSummaryIEnvelope } from '@verdocs/web-sdk';
+import type { SDKError as IVerdocsEnvelopeRecipientSummarySDKError } from '@verdocs/web-sdk';
 
 export declare interface VerdocsEnvelopeRecipientSummary extends Components.VerdocsEnvelopeRecipientSummary {
   /**
@@ -597,20 +623,24 @@ terminate the process, and the calling application should correct the condition 
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['endpoint', 'envelopeId'],
+  outputs: ['sdkError', 'envelopeUpdated', 'toggle', 'another'],
 })
 export class VerdocsEnvelopeSidebar {
   protected el: HTMLVerdocsEnvelopeSidebarElement;
+  @Output() sdkError = new EventEmitter<CustomEvent<IVerdocsEnvelopeSidebarSDKError>>();
+  @Output() envelopeUpdated = new EventEmitter<CustomEvent<{endpoint: IVerdocsEnvelopeSidebarVerdocsEndpoint; envelope: IVerdocsEnvelopeSidebarIEnvelope; event: string}>>();
+  @Output() toggle = new EventEmitter<CustomEvent<{open: boolean}>>();
+  @Output() another = new EventEmitter<CustomEvent<{envelope: IVerdocsEnvelopeSidebarIEnvelope}>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['sdkError', 'envelopeUpdated', 'toggle', 'another']);
   }
 }
 
 
-import type { SDKError as IVerdocsEnvelopeSidebarSDKError } from '@verdocs/web-sdk/components';
-import type { VerdocsEndpoint as IVerdocsEnvelopeSidebarVerdocsEndpoint } from '@verdocs/web-sdk/components';
-import type { IEnvelope as IVerdocsEnvelopeSidebarIEnvelope } from '@verdocs/web-sdk/components';
+import type { SDKError as IVerdocsEnvelopeSidebarSDKError } from '@verdocs/web-sdk';
+import type { VerdocsEndpoint as IVerdocsEnvelopeSidebarVerdocsEndpoint } from '@verdocs/web-sdk';
+import type { IEnvelope as IVerdocsEnvelopeSidebarIEnvelope } from '@verdocs/web-sdk';
 
 export declare interface VerdocsEnvelopeSidebar extends Components.VerdocsEnvelopeSidebar {
   /**
@@ -644,19 +674,21 @@ to redirect the user to the appropriate next workflow step.
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['endpoint', 'envelopeId', 'roleName'],
+  outputs: ['next', 'sdkError'],
 })
 export class VerdocsEnvelopeUpdateRecipient {
   protected el: HTMLVerdocsEnvelopeUpdateRecipientElement;
+  @Output() next = new EventEmitter<CustomEvent<{action: 'cancel' | 'save'; originalRecipient: IVerdocsEnvelopeUpdateRecipientIRecipient; updatedRecipient: IVerdocsEnvelopeUpdateRecipientIRecipient}>>();
+  @Output() sdkError = new EventEmitter<CustomEvent<IVerdocsEnvelopeUpdateRecipientSDKError>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['next', 'sdkError']);
   }
 }
 
 
-import type { IRecipient as IVerdocsEnvelopeUpdateRecipientIRecipient } from '@verdocs/web-sdk/components';
-import type { SDKError as IVerdocsEnvelopeUpdateRecipientSDKError } from '@verdocs/web-sdk/components';
+import type { IRecipient as IVerdocsEnvelopeUpdateRecipientIRecipient } from '@verdocs/web-sdk';
+import type { SDKError as IVerdocsEnvelopeUpdateRecipientSDKError } from '@verdocs/web-sdk';
 
 export declare interface VerdocsEnvelopeUpdateRecipient extends Components.VerdocsEnvelopeUpdateRecipient {
   /**
@@ -682,21 +714,28 @@ terminate the process, and the calling application should correct the condition 
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['endpoint', 'match', 'rowsPerPage', 'selectedPage', 'showPagination', 'sort', 'status', 'view'],
+  outputs: ['changeView', 'changeStatus', 'changeSort', 'changeMatch', 'sdkError', 'viewEnvelope', 'finishEnvelope'],
 })
 export class VerdocsEnvelopesList {
   protected el: HTMLVerdocsEnvelopesListElement;
+  @Output() changeView = new EventEmitter<CustomEvent<'all' | 'inbox' | 'sent' | 'completed' | 'action' | 'waiting'>>();
+  @Output() changeStatus = new EventEmitter<CustomEvent<IVerdocsEnvelopesListTEnvelopeStatus | 'all'>>();
+  @Output() changeSort = new EventEmitter<CustomEvent<'name' | 'created_at' | 'updated_at' | 'canceled_at' | 'status'>>();
+  @Output() changeMatch = new EventEmitter<CustomEvent<string>>();
+  @Output() sdkError = new EventEmitter<CustomEvent<IVerdocsEnvelopesListSDKError>>();
+  @Output() viewEnvelope = new EventEmitter<CustomEvent<{endpoint: IVerdocsEnvelopesListVerdocsEndpoint; envelope: IVerdocsEnvelopesListIEnvelope}>>();
+  @Output() finishEnvelope = new EventEmitter<CustomEvent<{endpoint: IVerdocsEnvelopesListVerdocsEndpoint; envelope: IVerdocsEnvelopesListIEnvelope}>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['changeView', 'changeStatus', 'changeSort', 'changeMatch', 'sdkError', 'viewEnvelope', 'finishEnvelope']);
   }
 }
 
 
-import type { TEnvelopeStatus as IVerdocsEnvelopesListTEnvelopeStatus } from '@verdocs/web-sdk/components';
-import type { SDKError as IVerdocsEnvelopesListSDKError } from '@verdocs/web-sdk/components';
-import type { VerdocsEndpoint as IVerdocsEnvelopesListVerdocsEndpoint } from '@verdocs/web-sdk/components';
-import type { IEnvelope as IVerdocsEnvelopesListIEnvelope } from '@verdocs/web-sdk/components';
+import type { TEnvelopeStatus as IVerdocsEnvelopesListTEnvelopeStatus } from '@verdocs/web-sdk';
+import type { SDKError as IVerdocsEnvelopesListSDKError } from '@verdocs/web-sdk';
+import type { VerdocsEndpoint as IVerdocsEnvelopesListVerdocsEndpoint } from '@verdocs/web-sdk';
+import type { IEnvelope as IVerdocsEnvelopesListIEnvelope } from '@verdocs/web-sdk';
 
 export declare interface VerdocsEnvelopesList extends Components.VerdocsEnvelopesList {
   /**
@@ -746,19 +785,22 @@ to the envelope detail view.
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['disabled', 'done', 'editable', 'field', 'fieldname', 'moveable', 'pagenumber', 'source', 'sourceid', 'xscale', 'yscale'],
+  outputs: ['settingsChanged', 'attached', 'deleted'],
 })
 export class VerdocsFieldAttachment {
   protected el: HTMLVerdocsFieldAttachmentElement;
+  @Output() settingsChanged = new EventEmitter<CustomEvent<{fieldName: string; field: IVerdocsFieldAttachmentITemplateField}>>();
+  @Output() attached = new EventEmitter<CustomEvent<IVerdocsFieldAttachmentISelectedFile>>();
+  @Output() deleted = new EventEmitter<CustomEvent<{fieldName: string}>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['settingsChanged', 'attached', 'deleted']);
   }
 }
 
 
-import type { ITemplateField as IVerdocsFieldAttachmentITemplateField } from '@verdocs/web-sdk/components';
-import type { ISelectedFile as IVerdocsFieldAttachmentISelectedFile } from '@verdocs/web-sdk/components';
+import type { ITemplateField as IVerdocsFieldAttachmentITemplateField } from '@verdocs/web-sdk';
+import type { ISelectedFile as IVerdocsFieldAttachmentISelectedFile } from '@verdocs/web-sdk';
 
 export declare interface VerdocsFieldAttachment extends Components.VerdocsFieldAttachment {
   /**
@@ -788,18 +830,20 @@ Build) not for any attachments (during signing).
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['disabled', 'done', 'editable', 'field', 'fieldname', 'moveable', 'pagenumber', 'source', 'sourceid', 'xscale', 'yscale'],
+  outputs: ['settingsChanged', 'deleted'],
 })
 export class VerdocsFieldCheckbox {
   protected el: HTMLVerdocsFieldCheckboxElement;
+  @Output() settingsChanged = new EventEmitter<CustomEvent<{fieldName: string; field: IVerdocsFieldCheckboxITemplateField}>>();
+  @Output() deleted = new EventEmitter<CustomEvent<{fieldName: string}>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['settingsChanged', 'deleted']);
   }
 }
 
 
-import type { ITemplateField as IVerdocsFieldCheckboxITemplateField } from '@verdocs/web-sdk/components';
+import type { ITemplateField as IVerdocsFieldCheckboxITemplateField } from '@verdocs/web-sdk';
 
 export declare interface VerdocsFieldCheckbox extends Components.VerdocsFieldCheckbox {
   /**
@@ -824,18 +868,21 @@ export declare interface VerdocsFieldCheckbox extends Components.VerdocsFieldChe
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['disabled', 'done', 'editable', 'field', 'fieldname', 'moveable', 'pagenumber', 'source', 'sourceid', 'xscale', 'yscale'],
+  outputs: ['settingsPress', 'settingsChanged', 'deleted'],
 })
 export class VerdocsFieldDate {
   protected el: HTMLVerdocsFieldDateElement;
+  @Output() settingsPress = new EventEmitter<CustomEvent<any>>();
+  @Output() settingsChanged = new EventEmitter<CustomEvent<{fieldName: string; field: IVerdocsFieldDateITemplateField}>>();
+  @Output() deleted = new EventEmitter<CustomEvent<{fieldName: string}>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['settingsPress', 'settingsChanged', 'deleted']);
   }
 }
 
 
-import type { ITemplateField as IVerdocsFieldDateITemplateField } from '@verdocs/web-sdk/components';
+import type { ITemplateField as IVerdocsFieldDateITemplateField } from '@verdocs/web-sdk';
 
 export declare interface VerdocsFieldDate extends Components.VerdocsFieldDate {
   /**
@@ -864,18 +911,21 @@ export declare interface VerdocsFieldDate extends Components.VerdocsFieldDate {
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['disabled', 'done', 'editable', 'field', 'fieldname', 'moveable', 'pagenumber', 'source', 'sourceid', 'xscale', 'yscale'],
+  outputs: ['fieldChange', 'settingsChanged', 'deleted'],
 })
 export class VerdocsFieldDropdown {
   protected el: HTMLVerdocsFieldDropdownElement;
+  @Output() fieldChange = new EventEmitter<CustomEvent<string>>();
+  @Output() settingsChanged = new EventEmitter<CustomEvent<{fieldName: string; field: IVerdocsFieldDropdownITemplateField}>>();
+  @Output() deleted = new EventEmitter<CustomEvent<{fieldName: string}>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['fieldChange', 'settingsChanged', 'deleted']);
   }
 }
 
 
-import type { ITemplateField as IVerdocsFieldDropdownITemplateField } from '@verdocs/web-sdk/components';
+import type { ITemplateField as IVerdocsFieldDropdownITemplateField } from '@verdocs/web-sdk';
 
 export declare interface VerdocsFieldDropdown extends Components.VerdocsFieldDropdown {
   /**
@@ -906,18 +956,24 @@ keypress.
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['disabled', 'done', 'editable', 'field', 'fieldname', 'initials', 'moveable', 'pagenumber', 'source', 'sourceid', 'xscale', 'yscale'],
+  outputs: ['adopt', 'exit', 'fieldChange', 'settingsChanged', 'settingsPress', 'deleted'],
 })
 export class VerdocsFieldInitial {
   protected el: HTMLVerdocsFieldInitialElement;
+  @Output() adopt = new EventEmitter<CustomEvent<string>>();
+  @Output() exit = new EventEmitter<CustomEvent<any>>();
+  @Output() fieldChange = new EventEmitter<CustomEvent<string>>();
+  @Output() settingsChanged = new EventEmitter<CustomEvent<{fieldName: string; field: IVerdocsFieldInitialITemplateField}>>();
+  @Output() settingsPress = new EventEmitter<CustomEvent<any>>();
+  @Output() deleted = new EventEmitter<CustomEvent<{fieldName: string}>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['adopt', 'exit', 'fieldChange', 'settingsChanged', 'settingsPress', 'deleted']);
   }
 }
 
 
-import type { ITemplateField as IVerdocsFieldInitialITemplateField } from '@verdocs/web-sdk/components';
+import type { ITemplateField as IVerdocsFieldInitialITemplateField } from '@verdocs/web-sdk';
 
 export declare interface VerdocsFieldInitial extends Components.VerdocsFieldInitial {
   /**
@@ -960,18 +1016,20 @@ keypress.
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['currentInitial', 'currentInitialId', 'currentSignature', 'currentSignatureId', 'disabled', 'done', 'editable', 'field', 'fieldId', 'fieldname', 'fields', 'moveable', 'pageNum', 'pagenumber', 'pdfPages', 'recipients', 'roleName', 'roleindex', 'selectedRoleName', 'signed', 'source', 'sourceid', 'xscale', 'yscale'],
+  outputs: ['settingsChanged', 'deleted'],
 })
 export class VerdocsFieldPayment {
   protected el: HTMLVerdocsFieldPaymentElement;
+  @Output() settingsChanged = new EventEmitter<CustomEvent<{fieldName: string; field: IVerdocsFieldPaymentITemplateField}>>();
+  @Output() deleted = new EventEmitter<CustomEvent<{fieldName: string}>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['settingsChanged', 'deleted']);
   }
 }
 
 
-import type { ITemplateField as IVerdocsFieldPaymentITemplateField } from '@verdocs/web-sdk/components';
+import type { ITemplateField as IVerdocsFieldPaymentITemplateField } from '@verdocs/web-sdk';
 
 export declare interface VerdocsFieldPayment extends Components.VerdocsFieldPayment {
   /**
@@ -996,18 +1054,20 @@ export declare interface VerdocsFieldPayment extends Components.VerdocsFieldPaym
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['disabled', 'done', 'editable', 'field', 'fieldname', 'moveable', 'pagenumber', 'required', 'source', 'sourceid', 'xscale', 'yscale'],
+  outputs: ['settingsChanged', 'deleted'],
 })
 export class VerdocsFieldRadio {
   protected el: HTMLVerdocsFieldRadioElement;
+  @Output() settingsChanged = new EventEmitter<CustomEvent<{fieldName: string; field: IVerdocsFieldRadioITemplateField}>>();
+  @Output() deleted = new EventEmitter<CustomEvent<{fieldName: string}>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['settingsChanged', 'deleted']);
   }
 }
 
 
-import type { ITemplateField as IVerdocsFieldRadioITemplateField } from '@verdocs/web-sdk/components';
+import type { ITemplateField as IVerdocsFieldRadioITemplateField } from '@verdocs/web-sdk';
 
 export declare interface VerdocsFieldRadio extends Components.VerdocsFieldRadio {
   /**
@@ -1032,18 +1092,22 @@ export declare interface VerdocsFieldRadio extends Components.VerdocsFieldRadio 
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['disabled', 'done', 'editable', 'field', 'fieldname', 'moveable', 'name', 'pagenumber', 'source', 'sourceid', 'xscale', 'yscale'],
+  outputs: ['fieldChange', 'settingsPress', 'settingsChanged', 'deleted'],
 })
 export class VerdocsFieldSignature {
   protected el: HTMLVerdocsFieldSignatureElement;
+  @Output() fieldChange = new EventEmitter<CustomEvent<string>>();
+  @Output() settingsPress = new EventEmitter<CustomEvent<any>>();
+  @Output() settingsChanged = new EventEmitter<CustomEvent<{fieldName: string; field: IVerdocsFieldSignatureITemplateField}>>();
+  @Output() deleted = new EventEmitter<CustomEvent<{fieldName: string}>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['fieldChange', 'settingsPress', 'settingsChanged', 'deleted']);
   }
 }
 
 
-import type { ITemplateField as IVerdocsFieldSignatureITemplateField } from '@verdocs/web-sdk/components';
+import type { ITemplateField as IVerdocsFieldSignatureITemplateField } from '@verdocs/web-sdk';
 
 export declare interface VerdocsFieldSignature extends Components.VerdocsFieldSignature {
   /**
@@ -1076,18 +1140,20 @@ export declare interface VerdocsFieldSignature extends Components.VerdocsFieldSi
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['disabled', 'done', 'editable', 'endpoint', 'field', 'fieldname', 'moveable', 'pagenumber', 'source', 'sourceid', 'xscale', 'yscale'],
+  outputs: ['settingsChanged', 'deleted'],
 })
 export class VerdocsFieldTextarea {
   protected el: HTMLVerdocsFieldTextareaElement;
+  @Output() settingsChanged = new EventEmitter<CustomEvent<{fieldName: string; field: IVerdocsFieldTextareaITemplateField}>>();
+  @Output() deleted = new EventEmitter<CustomEvent<{fieldName: string}>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['settingsChanged', 'deleted']);
   }
 }
 
 
-import type { ITemplateField as IVerdocsFieldTextareaITemplateField } from '@verdocs/web-sdk/components';
+import type { ITemplateField as IVerdocsFieldTextareaITemplateField } from '@verdocs/web-sdk';
 
 export declare interface VerdocsFieldTextarea extends Components.VerdocsFieldTextarea {
   /**
@@ -1112,18 +1178,20 @@ export declare interface VerdocsFieldTextarea extends Components.VerdocsFieldTex
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['disabled', 'done', 'editable', 'field', 'fieldname', 'moveable', 'multiline', 'pagenumber', 'source', 'sourceid', 'xscale', 'yscale'],
+  outputs: ['settingsChanged', 'deleted'],
 })
 export class VerdocsFieldTextbox {
   protected el: HTMLVerdocsFieldTextboxElement;
+  @Output() settingsChanged = new EventEmitter<CustomEvent<{fieldName: string; field: IVerdocsFieldTextboxITemplateField}>>();
+  @Output() deleted = new EventEmitter<CustomEvent<{fieldName: string}>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['settingsChanged', 'deleted']);
   }
 }
 
 
-import type { ITemplateField as IVerdocsFieldTextboxITemplateField } from '@verdocs/web-sdk/components';
+import type { ITemplateField as IVerdocsFieldTextboxITemplateField } from '@verdocs/web-sdk';
 
 export declare interface VerdocsFieldTextbox extends Components.VerdocsFieldTextbox {
   /**
@@ -1148,18 +1216,20 @@ export declare interface VerdocsFieldTextbox extends Components.VerdocsFieldText
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['disabled', 'done', 'editable', 'field', 'fieldname', 'moveable', 'pagenumber', 'source', 'sourceid', 'xscale', 'yscale'],
+  outputs: ['settingsChanged', 'deleted'],
 })
 export class VerdocsFieldTimestamp {
   protected el: HTMLVerdocsFieldTimestampElement;
+  @Output() settingsChanged = new EventEmitter<CustomEvent<{fieldName: string; field: IVerdocsFieldTimestampITemplateField}>>();
+  @Output() deleted = new EventEmitter<CustomEvent<{fieldName: string}>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['settingsChanged', 'deleted']);
   }
 }
 
 
-import type { ITemplateField as IVerdocsFieldTimestampITemplateField } from '@verdocs/web-sdk/components';
+import type { ITemplateField as IVerdocsFieldTimestampITemplateField } from '@verdocs/web-sdk';
 
 export declare interface VerdocsFieldTimestamp extends Components.VerdocsFieldTimestamp {
   /**
@@ -1183,13 +1253,14 @@ export declare interface VerdocsFieldTimestamp extends Components.VerdocsFieldTi
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['endpoint'],
+  outputs: ['fileSelected'],
 })
 export class VerdocsFileChooser {
   protected el: HTMLVerdocsFileChooserElement;
+  @Output() fileSelected = new EventEmitter<CustomEvent<{file: File | null}>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['fileSelected']);
   }
 }
 
@@ -1236,13 +1307,15 @@ export declare interface VerdocsHelpIcon extends Components.VerdocsHelpIcon {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['initials'],
+  outputs: ['next', 'exit'],
 })
 export class VerdocsInitialDialog {
   protected el: HTMLVerdocsInitialDialogElement;
+  @Output() next = new EventEmitter<CustomEvent<string>>();
+  @Output() exit = new EventEmitter<CustomEvent<any>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['next', 'exit']);
   }
 }
 
@@ -1270,18 +1343,21 @@ representation of the initials adopted.
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['choices', 'helptext', 'helptitle', 'label', 'mode', 'placeholder', 'recipient', 'step', 'steps'],
+  outputs: ['exit', 'pinEntered', 'next'],
 })
 export class VerdocsKbaDialog {
   protected el: HTMLVerdocsKbaDialogElement;
+  @Output() exit = new EventEmitter<CustomEvent<any>>();
+  @Output() pinEntered = new EventEmitter<CustomEvent<IVerdocsKbaDialogstring | IRecipient>>();
+  @Output() next = new EventEmitter<CustomEvent<IVerdocsKbaDialogstring | IVerdocsKbaDialogIRecipient | string[]>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['exit', 'pinEntered', 'next']);
   }
 }
 
 
-import type { IRecipient as IVerdocsKbaDialogIRecipient } from '@verdocs/web-sdk/components';
+import type { IRecipient as IVerdocsKbaDialogIRecipient } from '@verdocs/web-sdk';
 
 export declare interface VerdocsKbaDialog extends Components.VerdocsKbaDialog {
   /**
@@ -1333,13 +1409,14 @@ export declare interface VerdocsLoader extends Components.VerdocsLoader {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['overlay', 'side', 'width'],
+  outputs: ['close'],
 })
 export class VerdocsMenuPanel {
   protected el: HTMLVerdocsMenuPanelElement;
+  @Output() close = new EventEmitter<CustomEvent<void>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['close']);
   }
 }
 
@@ -1360,13 +1437,14 @@ export declare interface VerdocsMenuPanel extends Components.VerdocsMenuPanel {
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['label', 'options', 'placeholder', 'selectedOptions'],
+  outputs: ['selectionChanged'],
 })
 export class VerdocsMultiselect {
   protected el: HTMLVerdocsMultiselectElement;
+  @Output() selectionChanged = new EventEmitter<CustomEvent<{selectedOptions: string[]}>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['selectionChanged']);
   }
 }
 
@@ -1387,13 +1465,15 @@ export declare interface VerdocsMultiselect extends Components.VerdocsMultiselec
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['buttonLabel', 'heading', 'message', 'showCancel'],
+  outputs: ['next', 'exit'],
 })
 export class VerdocsOkDialog {
   protected el: HTMLVerdocsOkDialogElement;
+  @Output() next = new EventEmitter<CustomEvent<any>>();
+  @Output() exit = new EventEmitter<CustomEvent<any>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['next', 'exit']);
   }
 }
 
@@ -1443,18 +1523,20 @@ export declare interface VerdocsOrganizationCard extends Components.VerdocsOrgan
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['endpoint', 'method', 'recipient'],
+  outputs: ['exit', 'next'],
 })
 export class VerdocsOtpDialog {
   protected el: HTMLVerdocsOtpDialogElement;
+  @Output() exit = new EventEmitter<CustomEvent<any>>();
+  @Output() next = new EventEmitter<CustomEvent<{response: IVerdocsOtpDialogISignerTokenResponse}>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['exit', 'next']);
   }
 }
 
 
-import type { ISignerTokenResponse as IVerdocsOtpDialogISignerTokenResponse } from '@verdocs/web-sdk/components';
+import type { ISignerTokenResponse as IVerdocsOtpDialogISignerTokenResponse } from '@verdocs/web-sdk';
 
 export declare interface VerdocsOtpDialog extends Components.VerdocsOtpDialog {
   /**
@@ -1478,13 +1560,14 @@ export declare interface VerdocsOtpDialog extends Components.VerdocsOtpDialog {
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['itemCount', 'perPage', 'selectedPage'],
+  outputs: ['selectPage'],
 })
 export class VerdocsPagination {
   protected el: HTMLVerdocsPaginationElement;
+  @Output() selectPage = new EventEmitter<CustomEvent<{selectedPage: number}>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['selectPage']);
   }
 }
 
@@ -1507,13 +1590,14 @@ export declare interface VerdocsPagination extends Components.VerdocsPagination 
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['anchor', 'voffset'],
+  outputs: ['clickAway'],
 })
 export class VerdocsPortal {
   protected el: HTMLVerdocsPortalElement;
+  @Output() clickAway = new EventEmitter<CustomEvent<void>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['clickAway']);
   }
 }
 
@@ -1534,18 +1618,19 @@ export declare interface VerdocsPortal extends Components.VerdocsPortal {
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['endpoint', 'templateId'],
+  outputs: ['sdkError'],
 })
 export class VerdocsPreview {
   protected el: HTMLVerdocsPreviewElement;
+  @Output() sdkError = new EventEmitter<CustomEvent<IVerdocsPreviewSDKError>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['sdkError']);
   }
 }
 
 
-import type { SDKError as IVerdocsPreviewSDKError } from '@verdocs/web-sdk/components';
+import type { SDKError as IVerdocsPreviewSDKError } from '@verdocs/web-sdk';
 
 export declare interface VerdocsPreview extends Components.VerdocsPreview {
   /**
@@ -1589,18 +1674,19 @@ export declare interface VerdocsProgressBar extends Components.VerdocsProgressBa
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['label', 'options', 'placeholder', 'value'],
+  outputs: ['optionSelected'],
 })
 export class VerdocsQuickFilter {
   protected el: HTMLVerdocsQuickFilterElement;
+  @Output() optionSelected = new EventEmitter<CustomEvent<IVerdocsQuickFilterIFilterOption>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['optionSelected']);
   }
 }
 
 
-import type { IFilterOption as IVerdocsQuickFilterIFilterOption } from '@verdocs/web-sdk/components';
+import type { IFilterOption as IVerdocsQuickFilterIFilterOption } from '@verdocs/web-sdk';
 
 export declare interface VerdocsQuickFilter extends Components.VerdocsQuickFilter {
   /**
@@ -1621,13 +1707,15 @@ Web Component events need to be "composed" to cross the Shadow DOM and be receiv
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['endpoint'],
+  outputs: ['createTemplate', 'createDocument'],
 })
 export class VerdocsQuickFunctions {
   protected el: HTMLVerdocsQuickFunctionsElement;
+  @Output() createTemplate = new EventEmitter<CustomEvent<any>>();
+  @Output() createDocument = new EventEmitter<CustomEvent<any>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['createTemplate', 'createDocument']);
   }
 }
 
@@ -1678,19 +1766,22 @@ export declare interface VerdocsRadioButton extends Components.VerdocsRadioButto
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['endpoint', 'grabsFocus', 'placeholder', 'query', 'type'],
+  outputs: ['searchClicked', 'typeChanged', 'queryChanged'],
 })
 export class VerdocsSearchBox {
   protected el: HTMLVerdocsSearchBoxElement;
+  @Output() searchClicked = new EventEmitter<CustomEvent<IVerdocsSearchBoxISearchEvent>>();
+  @Output() typeChanged = new EventEmitter<CustomEvent<IVerdocsSearchBoxTContentType>>();
+  @Output() queryChanged = new EventEmitter<CustomEvent<string>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['searchClicked', 'typeChanged', 'queryChanged']);
   }
 }
 
 
-import type { ISearchEvent as IVerdocsSearchBoxISearchEvent } from '@verdocs/web-sdk/components';
-import type { TContentType as IVerdocsSearchBoxTContentType } from '@verdocs/web-sdk/components';
+import type { ISearchEvent as IVerdocsSearchBoxISearchEvent } from '@verdocs/web-sdk';
+import type { TContentType as IVerdocsSearchBoxTContentType } from '@verdocs/web-sdk';
 
 export declare interface VerdocsSearchBox extends Components.VerdocsSearchBox {
   /**
@@ -1764,22 +1855,27 @@ export declare interface VerdocsSelectInput extends Components.VerdocsSelectInpu
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['endpoint', 'environment', 'templateId'],
+  outputs: ['beforeSend', 'send', 'exit', 'sdkError', 'searchContacts'],
 })
 export class VerdocsSend {
   protected el: HTMLVerdocsSendElement;
+  @Output() beforeSend = new EventEmitter<CustomEvent<{recipients: IVerdocsSendICreateEnvelopeRecipientFromTemplate[]; name: string; template_id: string; template: IVerdocsSendITemplate}>>();
+  @Output() send = new EventEmitter<CustomEvent<{recipients: IVerdocsSendICreateEnvelopeRecipientFromTemplate[]; name: string; template_id: string; envelope_id: string; envelope: IVerdocsSendIEnvelope}>>();
+  @Output() exit = new EventEmitter<CustomEvent<any>>();
+  @Output() sdkError = new EventEmitter<CustomEvent<IVerdocsSendSDKError>>();
+  @Output() searchContacts = new EventEmitter<CustomEvent<IVerdocsSendIContactSearchEvent>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['beforeSend', 'send', 'exit', 'sdkError', 'searchContacts']);
   }
 }
 
 
-import type { ICreateEnvelopeRecipientFromTemplate as IVerdocsSendICreateEnvelopeRecipientFromTemplate } from '@verdocs/web-sdk/components';
-import type { ITemplate as IVerdocsSendITemplate } from '@verdocs/web-sdk/components';
-import type { IEnvelope as IVerdocsSendIEnvelope } from '@verdocs/web-sdk/components';
-import type { SDKError as IVerdocsSendSDKError } from '@verdocs/web-sdk/components';
-import type { IContactSearchEvent as IVerdocsSendIContactSearchEvent } from '@verdocs/web-sdk/components';
+import type { ICreateEnvelopeRecipientFromTemplate as IVerdocsSendICreateEnvelopeRecipientFromTemplate } from '@verdocs/web-sdk';
+import type { ITemplate as IVerdocsSendITemplate } from '@verdocs/web-sdk';
+import type { IEnvelope as IVerdocsSendIEnvelope } from '@verdocs/web-sdk';
+import type { SDKError as IVerdocsSendSDKError } from '@verdocs/web-sdk';
+import type { IContactSearchEvent as IVerdocsSendIContactSearchEvent } from '@verdocs/web-sdk';
 
 export declare interface VerdocsSend extends Components.VerdocsSend {
   /**
@@ -1817,20 +1913,23 @@ the `contactSuggestions` property.
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['endpoint', 'envelopeId', 'headerTargetId', 'inviteCode', 'roleId'],
+  outputs: ['sdkError', 'envelopeLoaded', 'envelopeUpdated'],
 })
 export class VerdocsSign {
   protected el: HTMLVerdocsSignElement;
+  @Output() sdkError = new EventEmitter<CustomEvent<IVerdocsSignSDKError>>();
+  @Output() envelopeLoaded = new EventEmitter<CustomEvent<{endpoint: IVerdocsSignVerdocsEndpoint; envelope: IVerdocsSignIEnvelope}>>();
+  @Output() envelopeUpdated = new EventEmitter<CustomEvent<{endpoint: IVerdocsSignVerdocsEndpoint; envelope: IVerdocsSignIEnvelope; event: string}>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['sdkError', 'envelopeLoaded', 'envelopeUpdated']);
   }
 }
 
 
-import type { SDKError as IVerdocsSignSDKError } from '@verdocs/web-sdk/components';
-import type { VerdocsEndpoint as IVerdocsSignVerdocsEndpoint } from '@verdocs/web-sdk/components';
-import type { IEnvelope as IVerdocsSignIEnvelope } from '@verdocs/web-sdk/components';
+import type { SDKError as IVerdocsSignSDKError } from '@verdocs/web-sdk';
+import type { VerdocsEndpoint as IVerdocsSignVerdocsEndpoint } from '@verdocs/web-sdk';
+import type { IEnvelope as IVerdocsSignIEnvelope } from '@verdocs/web-sdk';
 
 export declare interface VerdocsSign extends Components.VerdocsSign {
   /**
@@ -1859,13 +1958,15 @@ terminate the process, and the calling application should correct the condition 
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['name'],
+  outputs: ['next', 'exit'],
 })
 export class VerdocsSignatureDialog {
   protected el: HTMLVerdocsSignatureDialogElement;
+  @Output() next = new EventEmitter<CustomEvent<string>>();
+  @Output() exit = new EventEmitter<CustomEvent<any>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['next', 'exit']);
   }
 }
 
@@ -1939,13 +2040,14 @@ export declare interface VerdocsStatusIndicator extends Components.VerdocsStatus
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['checked', 'disabled', 'theme'],
+  outputs: ['checkedChange'],
 })
 export class VerdocsSwitch {
   protected el: HTMLVerdocsSwitchElement;
+  @Output() checkedChange = new EventEmitter<CustomEvent<boolean>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['checkedChange']);
   }
 }
 
@@ -1966,24 +2068,26 @@ export declare interface VerdocsSwitch extends Components.VerdocsSwitch {
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['columns', 'data'],
+  outputs: ['colHeaderClick', 'rowClick'],
 })
 export class VerdocsTable {
   protected el: HTMLVerdocsTableElement;
+  @Output() colHeaderClick = new EventEmitter<CustomEvent<{col: any}>>();
+  @Output() rowClick = new EventEmitter<CustomEvent<{row: any}>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['colHeaderClick', 'rowClick']);
   }
 }
 
 
-import type { IColumn as IVerdocsTableIColumn } from '@verdocs/web-sdk/components';
+import type { IColumn as IVerdocsTableIColumn } from '@verdocs/web-sdk';
 
 export declare interface VerdocsTable extends Components.VerdocsTable {
   /**
    * Event fired when the user clicks a column header. This may be used to manage sorting options.
    */
-  colHeaderClick: EventEmitter<CustomEvent<{col: [object Object]}>>;
+  colHeaderClick: EventEmitter<CustomEvent<{col: any}>>;
   /**
    * Event fired when the user clicks a row.
    */
@@ -2001,25 +2105,26 @@ export declare interface VerdocsTable extends Components.VerdocsTable {
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['selectedTab', 'tabs'],
+  outputs: ['selectTab'],
 })
 export class VerdocsTabs {
   protected el: HTMLVerdocsTabsElement;
+  @Output() selectTab = new EventEmitter<CustomEvent<{tab: any; index: number}>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['selectTab']);
   }
 }
 
 
-import type { ITab as IVerdocsTabsITab } from '@verdocs/web-sdk/components';
+import type { ITab as IVerdocsTabsITab } from '@verdocs/web-sdk';
 
 export declare interface VerdocsTabs extends Components.VerdocsTabs {
   /**
    * Event fired when the user clicks a template to view it. Typically the host application will use this to navigate
 to the template preview. This is also fired when the user selects "Preview/Send" fropm the dropdown menu.
    */
-  selectTab: EventEmitter<CustomEvent<{tab: [object Object]; index: number}>>;
+  selectTab: EventEmitter<CustomEvent<{tab: any; index: number}>>;
 }
 
 
@@ -2033,20 +2138,24 @@ to the template preview. This is also fired when the user selects "Preview/Send"
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['endpoint', 'templateId'],
+  outputs: ['exit', 'next', 'templateUpdated', 'sdkError'],
 })
 export class VerdocsTemplateAttachments {
   protected el: HTMLVerdocsTemplateAttachmentsElement;
+  @Output() exit = new EventEmitter<CustomEvent<any>>();
+  @Output() next = new EventEmitter<CustomEvent<{template: IVerdocsTemplateAttachmentsITemplate}>>();
+  @Output() templateUpdated = new EventEmitter<CustomEvent<{endpoint: IVerdocsTemplateAttachmentsVerdocsEndpoint; template: IVerdocsTemplateAttachmentsITemplate; event: string}>>();
+  @Output() sdkError = new EventEmitter<CustomEvent<IVerdocsTemplateAttachmentsSDKError>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['exit', 'next', 'templateUpdated', 'sdkError']);
   }
 }
 
 
-import type { ITemplate as IVerdocsTemplateAttachmentsITemplate } from '@verdocs/web-sdk/components';
-import type { VerdocsEndpoint as IVerdocsTemplateAttachmentsVerdocsEndpoint } from '@verdocs/web-sdk/components';
-import type { SDKError as IVerdocsTemplateAttachmentsSDKError } from '@verdocs/web-sdk/components';
+import type { ITemplate as IVerdocsTemplateAttachmentsITemplate } from '@verdocs/web-sdk';
+import type { VerdocsEndpoint as IVerdocsTemplateAttachmentsVerdocsEndpoint } from '@verdocs/web-sdk';
+import type { SDKError as IVerdocsTemplateAttachmentsSDKError } from '@verdocs/web-sdk';
 
 export declare interface VerdocsTemplateAttachments extends Components.VerdocsTemplateAttachments {
   /**
@@ -2079,19 +2188,21 @@ terminate the process, and the calling application should correct the condition 
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['endpoint', 'step', 'templateId'],
+  outputs: ['sdkError', 'stepChanged'],
 })
 export class VerdocsTemplateBuildTabs {
   protected el: HTMLVerdocsTemplateBuildTabsElement;
+  @Output() sdkError = new EventEmitter<CustomEvent<IVerdocsTemplateBuildTabsSDKError>>();
+  @Output() stepChanged = new EventEmitter<CustomEvent<IVerdocsTemplateBuildTabsTVerdocsBuildStep>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['sdkError', 'stepChanged']);
   }
 }
 
 
-import type { SDKError as IVerdocsTemplateBuildTabsSDKError } from '@verdocs/web-sdk/components';
-import type { TVerdocsBuildStep as IVerdocsTemplateBuildTabsTVerdocsBuildStep } from '@verdocs/web-sdk/components';
+import type { SDKError as IVerdocsTemplateBuildTabsSDKError } from '@verdocs/web-sdk';
+import type { TVerdocsBuildStep as IVerdocsTemplateBuildTabsTVerdocsBuildStep } from '@verdocs/web-sdk';
 
 export declare interface VerdocsTemplateBuildTabs extends Components.VerdocsTemplateBuildTabs {
   /**
@@ -2139,20 +2250,24 @@ export declare interface VerdocsTemplateCard extends Components.VerdocsTemplateC
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['endpoint', 'maxSize'],
+  outputs: ['exit', 'next', 'sdkError', 'templateCreated'],
 })
 export class VerdocsTemplateCreate {
   protected el: HTMLVerdocsTemplateCreateElement;
+  @Output() exit = new EventEmitter<CustomEvent<any>>();
+  @Output() next = new EventEmitter<CustomEvent<IVerdocsTemplateCreateITemplate>>();
+  @Output() sdkError = new EventEmitter<CustomEvent<IVerdocsTemplateCreateSDKError>>();
+  @Output() templateCreated = new EventEmitter<CustomEvent<{endpoint: IVerdocsTemplateCreateVerdocsEndpoint; template: IVerdocsTemplateCreateITemplate; templateId: string}>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['exit', 'next', 'sdkError', 'templateCreated']);
   }
 }
 
 
-import type { ITemplate as IVerdocsTemplateCreateITemplate } from '@verdocs/web-sdk/components';
-import type { SDKError as IVerdocsTemplateCreateSDKError } from '@verdocs/web-sdk/components';
-import type { VerdocsEndpoint as IVerdocsTemplateCreateVerdocsEndpoint } from '@verdocs/web-sdk/components';
+import type { ITemplate as IVerdocsTemplateCreateITemplate } from '@verdocs/web-sdk';
+import type { SDKError as IVerdocsTemplateCreateSDKError } from '@verdocs/web-sdk';
+import type { VerdocsEndpoint as IVerdocsTemplateCreateVerdocsEndpoint } from '@verdocs/web-sdk';
 
 export declare interface VerdocsTemplateCreate extends Components.VerdocsTemplateCreate {
   /**
@@ -2185,18 +2300,19 @@ terminate the process, and the calling application should correct the condition 
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['disabled', 'documentId', 'done', 'editable', 'endpoint', 'layers', 'pageNumber', 'templateId', 'virtualHeight', 'virtualWidth'],
+  outputs: ['pageRendered'],
 })
 export class VerdocsTemplateDocumentPage {
   protected el: HTMLVerdocsTemplateDocumentPageElement;
+  @Output() pageRendered = new EventEmitter<CustomEvent<IVerdocsTemplateDocumentPageIDocumentPageInfo>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['pageRendered']);
   }
 }
 
 
-import type { IDocumentPageInfo as IVerdocsTemplateDocumentPageIDocumentPageInfo } from '@verdocs/web-sdk/components';
+import type { IDocumentPageInfo as IVerdocsTemplateDocumentPageIDocumentPageInfo } from '@verdocs/web-sdk';
 
 export declare interface VerdocsTemplateDocumentPage extends Components.VerdocsTemplateDocumentPage {
   /**
@@ -2216,19 +2332,23 @@ export declare interface VerdocsTemplateDocumentPage extends Components.VerdocsT
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['endpoint', 'fieldName', 'helpText', 'templateId'],
+  outputs: ['close', 'delete', 'settingsChanged', 'sdkError'],
 })
 export class VerdocsTemplateFieldProperties {
   protected el: HTMLVerdocsTemplateFieldPropertiesElement;
+  @Output() close = new EventEmitter<CustomEvent<any>>();
+  @Output() delete = new EventEmitter<CustomEvent<{templateId: string; roleName: string}>>();
+  @Output() settingsChanged = new EventEmitter<CustomEvent<{fieldName: string; field: IVerdocsTemplateFieldPropertiesITemplateField}>>();
+  @Output() sdkError = new EventEmitter<CustomEvent<IVerdocsTemplateFieldPropertiesSDKError>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['close', 'delete', 'settingsChanged', 'sdkError']);
   }
 }
 
 
-import type { ITemplateField as IVerdocsTemplateFieldPropertiesITemplateField } from '@verdocs/web-sdk/components';
-import type { SDKError as IVerdocsTemplateFieldPropertiesSDKError } from '@verdocs/web-sdk/components';
+import type { ITemplateField as IVerdocsTemplateFieldPropertiesITemplateField } from '@verdocs/web-sdk';
+import type { SDKError as IVerdocsTemplateFieldPropertiesSDKError } from '@verdocs/web-sdk';
 
 export declare interface VerdocsTemplateFieldProperties extends Components.VerdocsTemplateFieldProperties {
   /**
@@ -2262,21 +2382,24 @@ terminate the process, and the calling application should correct the condition 
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['endpoint', 'templateId', 'toolbarTargetId'],
+  outputs: ['sdkError', 'templateUpdated', 'fieldsUpdated'],
 })
 export class VerdocsTemplateFields {
   protected el: HTMLVerdocsTemplateFieldsElement;
+  @Output() sdkError = new EventEmitter<CustomEvent<IVerdocsTemplateFieldsSDKError>>();
+  @Output() templateUpdated = new EventEmitter<CustomEvent<{endpoint: IVerdocsTemplateFieldsVerdocsEndpoint; template: IVerdocsTemplateFieldsITemplate; event: string}>>();
+  @Output() fieldsUpdated = new EventEmitter<CustomEvent<{endpoint: IVerdocsTemplateFieldsVerdocsEndpoint; templateId: string; event: 'added' | 'deleted' | 'updated'; fields: IVerdocsTemplateFieldsITemplateField[]}>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['sdkError', 'templateUpdated', 'fieldsUpdated']);
   }
 }
 
 
-import type { SDKError as IVerdocsTemplateFieldsSDKError } from '@verdocs/web-sdk/components';
-import type { VerdocsEndpoint as IVerdocsTemplateFieldsVerdocsEndpoint } from '@verdocs/web-sdk/components';
-import type { ITemplate as IVerdocsTemplateFieldsITemplate } from '@verdocs/web-sdk/components';
-import type { ITemplateField as IVerdocsTemplateFieldsITemplateField } from '@verdocs/web-sdk/components';
+import type { SDKError as IVerdocsTemplateFieldsSDKError } from '@verdocs/web-sdk';
+import type { VerdocsEndpoint as IVerdocsTemplateFieldsVerdocsEndpoint } from '@verdocs/web-sdk';
+import type { ITemplate as IVerdocsTemplateFieldsITemplate } from '@verdocs/web-sdk';
+import type { ITemplateField as IVerdocsTemplateFieldsITemplateField } from '@verdocs/web-sdk';
 
 export declare interface VerdocsTemplateFields extends Components.VerdocsTemplateFields {
   /**
@@ -2303,18 +2426,21 @@ terminate the process, and the calling application should correct the condition 
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['endpoint', 'roleName', 'templateId'],
+  outputs: ['close', 'delete', 'sdkError'],
 })
 export class VerdocsTemplateRoleProperties {
   protected el: HTMLVerdocsTemplateRolePropertiesElement;
+  @Output() close = new EventEmitter<CustomEvent<any>>();
+  @Output() delete = new EventEmitter<CustomEvent<{templateId: string; roleName: string}>>();
+  @Output() sdkError = new EventEmitter<CustomEvent<IVerdocsTemplateRolePropertiesSDKError>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['close', 'delete', 'sdkError']);
   }
 }
 
 
-import type { SDKError as IVerdocsTemplateRolePropertiesSDKError } from '@verdocs/web-sdk/components';
+import type { SDKError as IVerdocsTemplateRolePropertiesSDKError } from '@verdocs/web-sdk';
 
 export declare interface VerdocsTemplateRoleProperties extends Components.VerdocsTemplateRoleProperties {
   /**
@@ -2344,20 +2470,24 @@ terminate the process, and the calling application should correct the condition 
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['endpoint', 'templateId'],
+  outputs: ['next', 'exit', 'sdkError', 'rolesUpdated'],
 })
 export class VerdocsTemplateRoles {
   protected el: HTMLVerdocsTemplateRolesElement;
+  @Output() next = new EventEmitter<CustomEvent<any>>();
+  @Output() exit = new EventEmitter<CustomEvent<any>>();
+  @Output() sdkError = new EventEmitter<CustomEvent<IVerdocsTemplateRolesSDKError>>();
+  @Output() rolesUpdated = new EventEmitter<CustomEvent<{endpoint: IVerdocsTemplateRolesVerdocsEndpoint; templateId: string; event: 'added' | 'deleted' | 'updated'; roles: IVerdocsTemplateRolesIRole[]}>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['next', 'exit', 'sdkError', 'rolesUpdated']);
   }
 }
 
 
-import type { SDKError as IVerdocsTemplateRolesSDKError } from '@verdocs/web-sdk/components';
-import type { VerdocsEndpoint as IVerdocsTemplateRolesVerdocsEndpoint } from '@verdocs/web-sdk/components';
-import type { IRole as IVerdocsTemplateRolesIRole } from '@verdocs/web-sdk/components';
+import type { SDKError as IVerdocsTemplateRolesSDKError } from '@verdocs/web-sdk';
+import type { VerdocsEndpoint as IVerdocsTemplateRolesVerdocsEndpoint } from '@verdocs/web-sdk';
+import type { IRole as IVerdocsTemplateRolesIRole } from '@verdocs/web-sdk';
 
 export declare interface VerdocsTemplateRoles extends Components.VerdocsTemplateRoles {
   /**
@@ -2390,20 +2520,24 @@ terminate the process, and the calling application should correct the condition 
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['endpoint', 'templateId'],
+  outputs: ['next', 'exit', 'sdkError', 'templateUpdated'],
 })
 export class VerdocsTemplateSettings {
   protected el: HTMLVerdocsTemplateSettingsElement;
+  @Output() next = new EventEmitter<CustomEvent<any>>();
+  @Output() exit = new EventEmitter<CustomEvent<any>>();
+  @Output() sdkError = new EventEmitter<CustomEvent<IVerdocsTemplateSettingsSDKError>>();
+  @Output() templateUpdated = new EventEmitter<CustomEvent<{endpoint: IVerdocsTemplateSettingsVerdocsEndpoint; template: IVerdocsTemplateSettingsITemplate; event: string}>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['next', 'exit', 'sdkError', 'templateUpdated']);
   }
 }
 
 
-import type { SDKError as IVerdocsTemplateSettingsSDKError } from '@verdocs/web-sdk/components';
-import type { VerdocsEndpoint as IVerdocsTemplateSettingsVerdocsEndpoint } from '@verdocs/web-sdk/components';
-import type { ITemplate as IVerdocsTemplateSettingsITemplate } from '@verdocs/web-sdk/components';
+import type { SDKError as IVerdocsTemplateSettingsSDKError } from '@verdocs/web-sdk';
+import type { VerdocsEndpoint as IVerdocsTemplateSettingsVerdocsEndpoint } from '@verdocs/web-sdk';
+import type { ITemplate as IVerdocsTemplateSettingsITemplate } from '@verdocs/web-sdk';
 
 export declare interface VerdocsTemplateSettings extends Components.VerdocsTemplateSettings {
   /**
@@ -2436,18 +2570,20 @@ terminate the process, and the calling application should correct the condition 
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['endpoint', 'template'],
+  outputs: ['starChange', 'sdkError'],
 })
 export class VerdocsTemplateStar {
   protected el: HTMLVerdocsTemplateStarElement;
+  @Output() starChange = new EventEmitter<CustomEvent<{templateId: string; starred: boolean; count: number}>>();
+  @Output() sdkError = new EventEmitter<CustomEvent<IVerdocsTemplateStarSDKError>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['starChange', 'sdkError']);
   }
 }
 
 
-import type { SDKError as IVerdocsTemplateStarSDKError } from '@verdocs/web-sdk/components';
+import type { SDKError as IVerdocsTemplateStarSDKError } from '@verdocs/web-sdk';
 
 export declare interface VerdocsTemplateStar extends Components.VerdocsTemplateStar {
   /**
@@ -2496,20 +2632,30 @@ export declare interface VerdocsTemplateTags extends Components.VerdocsTemplateT
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['allowedActions', 'endpoint', 'name', 'rowsPerPage', 'selectedPage', 'showPagination', 'sort', 'starred', 'visibility'],
+  outputs: ['sdkError', 'viewTemplate', 'signNow', 'submittedData', 'editTemplate', 'templateDeleted', 'changeSort', 'changeVisibility', 'changeStarred', 'changeName'],
 })
 export class VerdocsTemplatesList {
   protected el: HTMLVerdocsTemplatesListElement;
+  @Output() sdkError = new EventEmitter<CustomEvent<IVerdocsTemplatesListSDKError>>();
+  @Output() viewTemplate = new EventEmitter<CustomEvent<{endpoint: IVerdocsTemplatesListVerdocsEndpoint; template: IVerdocsTemplatesListITemplate}>>();
+  @Output() signNow = new EventEmitter<CustomEvent<{endpoint: IVerdocsTemplatesListVerdocsEndpoint; template: IVerdocsTemplatesListITemplate}>>();
+  @Output() submittedData = new EventEmitter<CustomEvent<{endpoint: IVerdocsTemplatesListVerdocsEndpoint; template: IVerdocsTemplatesListITemplate}>>();
+  @Output() editTemplate = new EventEmitter<CustomEvent<{endpoint: IVerdocsTemplatesListVerdocsEndpoint; template: IVerdocsTemplatesListITemplate}>>();
+  @Output() templateDeleted = new EventEmitter<CustomEvent<{endpoint: IVerdocsTemplatesListVerdocsEndpoint; template: IVerdocsTemplatesListITemplate}>>();
+  @Output() changeSort = new EventEmitter<CustomEvent<string>>();
+  @Output() changeVisibility = new EventEmitter<CustomEvent<'private_shared' | 'private' | 'shared' | 'public'>>();
+  @Output() changeStarred = new EventEmitter<CustomEvent<'all' | 'starred' | 'unstarred'>>();
+  @Output() changeName = new EventEmitter<CustomEvent<string>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['sdkError', 'viewTemplate', 'signNow', 'submittedData', 'editTemplate', 'templateDeleted', 'changeSort', 'changeVisibility', 'changeStarred', 'changeName']);
   }
 }
 
 
-import type { SDKError as IVerdocsTemplatesListSDKError } from '@verdocs/web-sdk/components';
-import type { VerdocsEndpoint as IVerdocsTemplatesListVerdocsEndpoint } from '@verdocs/web-sdk/components';
-import type { ITemplate as IVerdocsTemplatesListITemplate } from '@verdocs/web-sdk/components';
+import type { SDKError as IVerdocsTemplatesListSDKError } from '@verdocs/web-sdk';
+import type { VerdocsEndpoint as IVerdocsTemplatesListVerdocsEndpoint } from '@verdocs/web-sdk';
+import type { ITemplate as IVerdocsTemplatesListITemplate } from '@verdocs/web-sdk';
 
 export declare interface VerdocsTemplatesList extends Components.VerdocsTemplatesList {
   /**
@@ -2617,13 +2763,14 @@ export declare interface VerdocsToggle extends Components.VerdocsToggle {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['active', 'icon', 'label', 'size'],
+  outputs: ['toggle'],
 })
 export class VerdocsToggleButton {
   protected el: HTMLVerdocsToggleButtonElement;
+  @Output() toggle = new EventEmitter<CustomEvent<{active: boolean}>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['toggle']);
   }
 }
 
@@ -2669,13 +2816,16 @@ export declare interface VerdocsToolbarIcon extends Components.VerdocsToolbarIco
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['existingFile', 'maxSize'],
+  outputs: ['exit', 'next', 'remove'],
 })
 export class VerdocsUploadDialog {
   protected el: HTMLVerdocsUploadDialogElement;
+  @Output() exit = new EventEmitter<CustomEvent<any>>();
+  @Output() next = new EventEmitter<CustomEvent<File[]>>();
+  @Output() remove = new EventEmitter<CustomEvent<any>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['exit', 'next', 'remove']);
   }
 }
 
@@ -2707,20 +2857,25 @@ responsible for the actual removal.
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['endpoint', 'envelopeId', 'headerTargetId'],
+  outputs: ['sdkError', 'envelopeUpdated', 'another', 'view', 'next'],
 })
 export class VerdocsView {
   protected el: HTMLVerdocsViewElement;
+  @Output() sdkError = new EventEmitter<CustomEvent<IVerdocsViewSDKError>>();
+  @Output() envelopeUpdated = new EventEmitter<CustomEvent<{endpoint: IVerdocsViewVerdocsEndpoint; envelope: IVerdocsViewIEnvelope; event: string}>>();
+  @Output() another = new EventEmitter<CustomEvent<any>>();
+  @Output() view = new EventEmitter<CustomEvent<any>>();
+  @Output() next = new EventEmitter<CustomEvent<any>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['sdkError', 'envelopeUpdated', 'another', 'view', 'next']);
   }
 }
 
 
-import type { SDKError as IVerdocsViewSDKError } from '@verdocs/web-sdk/components';
-import type { VerdocsEndpoint as IVerdocsViewVerdocsEndpoint } from '@verdocs/web-sdk/components';
-import type { IEnvelope as IVerdocsViewIEnvelope } from '@verdocs/web-sdk/components';
+import type { SDKError as IVerdocsViewSDKError } from '@verdocs/web-sdk';
+import type { VerdocsEndpoint as IVerdocsViewVerdocsEndpoint } from '@verdocs/web-sdk';
+import type { IEnvelope as IVerdocsViewIEnvelope } from '@verdocs/web-sdk';
 
 export declare interface VerdocsView extends Components.VerdocsView {
   /**

--- a/verdocs-web-sdk-vue/package-lock.json
+++ b/verdocs-web-sdk-vue/package-lock.json
@@ -22,7 +22,7 @@
         "vue": "^3.5.13"
       },
       "peerDependencies": {
-        "vue": "^4",
+        "vue": "^3",
         "vue-router": "^4"
       }
     },

--- a/verdocs-web-sdk-vue/package.json
+++ b/verdocs-web-sdk-vue/package.json
@@ -22,7 +22,7 @@
     "@stencil/vue-output-target": "^0.10.8"
   },
   "peerDependencies": {
-    "vue": "^4",
+    "vue": "^3",
     "vue-router": "^4"
   },
   "devDependencies": {

--- a/verdocs-web-sdk/README.md
+++ b/verdocs-web-sdk/README.md
@@ -6,3 +6,52 @@ This is the core component library for a set of framework-specific SDKs to quick
 For more information, please see one of the following for your specific framework:
 
   - [Verdocs Web for React](https://www.npmjs.com/package/@verdocs/web-sdk-react)
+
+---
+
+## Vanilla JS Build & CDN Usage
+
+A single-file Vanilla JS bundle is now available for direct use in any HTML/JavaScript project (no framework required). This bundle auto-defines all Verdocs custom elements globally.
+
+### Building the Vanilla JS Bundle
+
+1. Build the Stencil outputs (required for the bundle to work):
+   ```bash
+   npm run build
+   ```
+2. From the `verdocs-web-sdk` subdirectory, run:
+   ```bash
+   npx rollup -c rollup.config.mjs
+   ```
+   This will create `dist/verdocs-web-sdk-vanilla.js`, which can be used directly in the browser or via CDN.
+
+3. Publish to npm as usual:
+   ```bash
+   npm publish
+   ```
+
+### Using via jsDelivr or CDNjs
+
+After publishing to npm, the bundle will be available via CDN. Example (replace `x.y.z` with the latest version):
+
+**jsDelivr:**
+```html
+<script src="https://cdn.jsdelivr.net/npm/@verdocs/web-sdk@x.y.z/dist/verdocs-web-sdk-vanilla.js"></script>
+```
+
+**CDNjs:**
+```html
+<script src="https://cdnjs.cloudflare.com/ajax/libs/verdocs-web-sdk/x.y.z/dist/verdocs-web-sdk-vanilla.js"></script>
+```
+
+Once included, all Verdocs custom elements will be available globally. Example usage:
+
+```html
+<verdocs-button label="Click me"></verdocs-button>
+```
+
+### Notes
+
+- No changes to Stencil config were required for this bundle, and Storybook/framework SDK outputs are unaffected.
+- For advanced usage or troubleshooting, see the StencilJS documentation on [custom elements bundles](https://stenciljs.com/docs/custom-elements).
+

--- a/verdocs-web-sdk/bundle-entry.js
+++ b/verdocs-web-sdk/bundle-entry.js
@@ -1,0 +1,4 @@
+import { defineCustomElements } from './dist/loader/index.js';
+
+// Register all components globally
+defineCustomElements(window);

--- a/verdocs-web-sdk/package-lock.json
+++ b/verdocs-web-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@verdocs/web-sdk",
-  "version": "6.0.5",
+  "version": "6.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@verdocs/web-sdk",
-      "version": "6.0.5",
+      "version": "6.0.4",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
@@ -19,6 +19,7 @@
         "imask": "^7.6.1",
         "interactjs": "^1.10.27",
         "jszip": "^3.10.1",
+        "rollup": "^4.48.1",
         "sortablejs": "^1.15.6",
         "tinybase": "^6.5.1",
         "workflow-svg.js": "^3.0.2"
@@ -26,7 +27,9 @@
       "devDependencies": {
         "@babel/core": "^7.28.0",
         "@interactjs/types": "^1.10.27",
-        "@stencil/angular-output-target": "^1.1.0",
+        "@rollup/plugin-commonjs": "^28.0.6",
+        "@rollup/plugin-node-resolve": "^16.0.1",
+        "@stencil/angular-output-target": "^1.1.1",
         "@stencil/react-output-target": "^1.2.0",
         "@stencil/sass": "^3.2.2",
         "@stencil/vue-output-target": "^0.10.8",
@@ -82,22 +85,22 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
-      "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.3.tgz",
+      "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.0",
+        "@babel/generator": "^7.28.3",
         "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.27.3",
-        "@babel/helpers": "^7.27.6",
-        "@babel/parser": "^7.28.0",
+        "@babel/helper-module-transforms": "^7.28.3",
+        "@babel/helpers": "^7.28.3",
+        "@babel/parser": "^7.28.3",
         "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.0",
-        "@babel/types": "^7.28.0",
+        "@babel/traverse": "^7.28.3",
+        "@babel/types": "^7.28.2",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -113,14 +116,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.0.tgz",
-      "integrity": "sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
+      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.0",
-        "@babel/types": "^7.28.0",
+        "@babel/parser": "^7.28.3",
+        "@babel/types": "^7.28.2",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -171,15 +174,15 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
-      "integrity": "sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
+      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.27.3"
+        "@babel/traverse": "^7.28.3"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -229,9 +232,9 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.2.tgz",
-      "integrity": "sha512-/V9771t+EgXz62aCcyofnQhGM8DQACbRhvzKFsXKC9QM+5MadF8ZmIm0crDMaz3+o0h0zXfJnd4EhbYbxsrcFw==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.3.tgz",
+      "integrity": "sha512-PTNtvUQihsAsDHMOP5pfobP8C6CM4JWXmP8DrEIt46c3r2bf87Ua1zoqevsMo9g+tWDwgWrFP5EIxuBx5RudAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -243,13 +246,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
-      "integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.3.tgz",
+      "integrity": "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.0"
+        "@babel/types": "^7.28.2"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -508,16 +511,10 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
-    "node_modules/@babel/polyfill/node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "license": "MIT"
-    },
     "node_modules/@babel/runtime-corejs3": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.28.0.tgz",
-      "integrity": "sha512-nlIXnSqLcBij8K8TtkxbBJgfzfvi75V1pAKSM7dUXejGw12vJAqez74jZrHTsJ3Z+Aczc5Q/6JgNjKRMsVU44g==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.28.3.tgz",
+      "integrity": "sha512-LKYxD2CIfocUFNREQ1yk+dW+8OH8CRqmgatBZYXb+XhuObO8wsDpEoCNri5bKld9cnj8xukqZjxSX8p1YiRF8Q==",
       "license": "MIT",
       "dependencies": {
         "core-js-pure": "^3.43.0"
@@ -542,18 +539,18 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.0.tgz",
-      "integrity": "sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.3.tgz",
+      "integrity": "sha512-7w4kZYHneL3A6NP2nxzHvT3HCZ7puDZZjFMqDpBPECub79sTtSO5CGXDkKrTQq8ksAwfD/XI2MRFX23njdDaIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.0",
+        "@babel/generator": "^7.28.3",
         "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.0",
+        "@babel/parser": "^7.28.3",
         "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.0",
+        "@babel/types": "^7.28.2",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -582,9 +579,9 @@
       "license": "MIT"
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.6.2.tgz",
-      "integrity": "sha512-vLu7SRY84CV/Dd+NUdgtidn2hS5hSMUC1vDBY0VcviTdgRYkU43vIz3vIFbmx14cX1r+mM7WjzE5Fl1fGEM0RQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.7.0.tgz",
+      "integrity": "sha512-qn6tAIZEw5i/wiESBF4nQxZkl86aY4KoO0IkUa2Lh+rya64oTOdJQFlZuMwI1Qz9VBJQrQC4QlSA2DNek5gCOA==",
       "dev": true,
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
@@ -613,6 +610,62 @@
         "get-package-type": "^0.1.0",
         "js-yaml": "^3.13.1",
         "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
       },
       "engines": {
         "node": ">=8"
@@ -921,9 +974,9 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
-      "integrity": "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -942,9 +995,9 @@
       }
     },
     "node_modules/@jridgewell/source-map": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
-      "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -953,16 +1006,16 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.29",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
-      "integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==",
+      "version": "0.3.30",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz",
+      "integrity": "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -971,9 +1024,9 @@
       }
     },
     "node_modules/@lit/react": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@lit/react/-/react-1.0.7.tgz",
-      "integrity": "sha512-cencnwwLXQKiKxjfFzSgZRngcWJzUDZi/04E0fSaF86wZgchMdvTyu+lE36DrUfvuus3bH8+xLPrhM1cTjwpzw==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@lit/react/-/react-1.0.8.tgz",
+      "integrity": "sha512-p2+YcF+JE67SRX3mMlJ1TKCSTsgyOVdAwd/nxp3NuV1+Cb6MWALbN6nT7Ld4tpmYofcE5kcaSY1YBB9erY+6fw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "peerDependencies": {
@@ -1018,6 +1071,316 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@parcel/watcher": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
+      "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^1.0.3",
+        "is-glob": "^4.0.3",
+        "micromatch": "^4.0.5",
+        "node-addon-api": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.5.1",
+        "@parcel/watcher-darwin-arm64": "2.5.1",
+        "@parcel/watcher-darwin-x64": "2.5.1",
+        "@parcel/watcher-freebsd-x64": "2.5.1",
+        "@parcel/watcher-linux-arm-glibc": "2.5.1",
+        "@parcel/watcher-linux-arm-musl": "2.5.1",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.1",
+        "@parcel/watcher-linux-arm64-musl": "2.5.1",
+        "@parcel/watcher-linux-x64-glibc": "2.5.1",
+        "@parcel/watcher-linux-x64-musl": "2.5.1",
+        "@parcel/watcher-win32-arm64": "2.5.1",
+        "@parcel/watcher-win32-ia32": "2.5.1",
+        "@parcel/watcher-win32-x64": "2.5.1"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz",
+      "integrity": "sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz",
+      "integrity": "sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz",
+      "integrity": "sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz",
+      "integrity": "sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz",
+      "integrity": "sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz",
+      "integrity": "sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz",
+      "integrity": "sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz",
+      "integrity": "sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz",
+      "integrity": "sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz",
+      "integrity": "sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz",
+      "integrity": "sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz",
+      "integrity": "sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz",
+      "integrity": "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
@@ -1029,9 +1392,9 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.10.6",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.6.tgz",
-      "integrity": "sha512-pHUn6ZRt39bP3698HFQlu2ZHCkS/lPcpv7fVQcGBSzNNygw171UXAKrCUhy+TEMw4lEttOKDgNpb04hwUAJeiQ==",
+      "version": "2.10.7",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.7.tgz",
+      "integrity": "sha512-wHWLkQWBjHtajZeqCB74nsa/X70KheyOhySYBRmVQDJiNj0zjZR/naPCvdWjMhcG1LmjaMV/9WtTo5mpe8qWLw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1063,6 +1426,133 @@
         "node": ">=10"
       }
     },
+    "node_modules/@rollup/plugin-commonjs": {
+      "version": "28.0.6",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.6.tgz",
+      "integrity": "sha512-XSQB1K7FUU5QP+3lOQmVCE3I0FcbbNvmNT4VJSj93iUjayaARrTQeoRdiYQoftAJBLrR9t2agwAd3ekaTgHNlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "commondir": "^1.0.1",
+        "estree-walker": "^2.0.2",
+        "fdir": "^6.2.0",
+        "is-reference": "1.2.1",
+        "magic-string": "^0.30.3",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0 || 14 >= 14.17"
+      },
+      "peerDependencies": {
+        "rollup": "^2.68.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@rollup/plugin-node-resolve": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-16.0.1.tgz",
+      "integrity": "sha512-tk5YCxJWIG81umIvNkSod2qK5KyQW19qcBF/B78n1bjtOON6gzKoVeSzAE8yHCZEDmqkHKkxplExA8KzdJLJpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "@types/resolve": "1.20.2",
+        "deepmerge": "^4.2.2",
+        "is-module": "^1.0.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.78.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.2.0.tgz",
+      "integrity": "sha512-qWJ2ZTbmumwiLFomfzTyt5Kng4hwPi9rwCYN4SHb6eaRU1KNO4ccxINHr/VhH4GgPlt1XfSTLX2LBTme8ne4Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.48.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.48.1.tgz",
+      "integrity": "sha512-rGmb8qoG/zdmKoYELCBwu7vt+9HxZ7Koos3pD0+sH5fR3u3Wb/jGcpnqxcnWsPEKDUyzeLSqksN8LJtgXjqBYw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.48.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.48.1.tgz",
+      "integrity": "sha512-4e9WtTxrk3gu1DFE+imNJr4WsL13nWbD/Y6wQcyku5qadlKHY3OQ3LJ/INrrjngv2BJIHnIzbqMk1GTAC2P8yQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.34.9",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.34.9.tgz",
@@ -1074,6 +1564,227 @@
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.34.9.tgz",
+      "integrity": "sha512-eOojSEAi/acnsJVYRxnMkPFqcxSMFfrw7r2iD9Q32SGkb/Q9FpUY1UlAu1DH9T7j++gZ0lHjnm4OyH2vCI7l7Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.48.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.48.1.tgz",
+      "integrity": "sha512-P9ViWakdoynYFUOZhqq97vBrhuvRLAbN/p2tAVJvhLb8SvN7rbBnJQcBu8e/rQts42pXGLVhfsAP0k9KXWa3nQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.48.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.48.1.tgz",
+      "integrity": "sha512-VLKIwIpnBya5/saccM8JshpbxfyJt0Dsli0PjXozHwbSVaHTvWXJH1bbCwPXxnMzU4zVEfgD1HpW3VQHomi2AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.48.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.48.1.tgz",
+      "integrity": "sha512-3zEuZsXfKaw8n/yF7t8N6NNdhyFw3s8xJTqjbTDXlipwrEHo4GtIKcMJr5Ed29leLpB9AugtAQpAHW0jvtKKaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.48.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.48.1.tgz",
+      "integrity": "sha512-leo9tOIlKrcBmmEypzunV/2w946JeLbTdDlwEZ7OnnsUyelZ72NMnT4B2vsikSgwQifjnJUbdXzuW4ToN1wV+Q==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.34.9.tgz",
+      "integrity": "sha512-6TZjPHjKZUQKmVKMUowF3ewHxctrRR09eYyvT5eFv8w/fXarEra83A2mHTVJLA5xU91aCNOUnM+DWFMSbQ0Nxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.34.9.tgz",
+      "integrity": "sha512-LD2fytxZJZ6xzOKnMbIpgzFOuIKlxVOpiMAXawsAZ2mHBPEYOnLRK5TTEsID6z4eM23DuO88X0Tq1mErHMVq0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+      "version": "4.48.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.48.1.tgz",
+      "integrity": "sha512-yzCaBbwkkWt/EcgJOKDUdUpMHjhiZT/eDktOPWvSRpqrVE04p0Nd6EGV4/g7MARXXeOqstflqsKuXVM3H9wOIQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.48.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.48.1.tgz",
+      "integrity": "sha512-UK0WzWUjMAJccHIeOpPhPcKBqax7QFg47hwZTp6kiMhQHeOYJeaMwzeRZe1q5IiTKsaLnHu9s6toSYVUlZ2QtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.48.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.48.1.tgz",
+      "integrity": "sha512-3NADEIlt+aCdCbWVZ7D3tBjBX1lHpXxcvrLt/kdXTiBrOds8APTdtk2yRL2GgmnSVeX4YS1JIf0imFujg78vpw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.48.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.48.1.tgz",
+      "integrity": "sha512-euuwm/QTXAMOcyiFCcrx0/S2jGvFlKJ2Iro8rsmYL53dlblp3LkUQVFzEidHhvIPPvcIsxDhl2wkBE+I6YVGzA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.48.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.48.1.tgz",
+      "integrity": "sha512-w8mULUjmPdWLJgmTYJx/W6Qhln1a+yqvgwmGXcQl2vFBkWsKGUBRbtLRuKJUln8Uaimf07zgJNxOhHOvjSQmBQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.34.9.tgz",
+      "integrity": "sha512-FwBHNSOjUTQLP4MG7y6rR6qbGw4MFeQnIBrMe161QGaQoBQLqSUEKlHIiVgF3g/mb3lxlxzJOpIBhaP+C+KP2A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.34.9.tgz",
+      "integrity": "sha512-cYRpV4650z2I3/s6+5/LONkjIz8MBeqrk+vPXV10ORBnshpn8S32bPqQ2Utv39jCiDcO2eJTuSlPXpnvmaIgRA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.34.9.tgz",
+      "integrity": "sha512-z4mQK9dAN6byRA/vsSgQiPeuO63wdiDxZ9yg9iyX2QTzKuQM7T4xlBoeUP/J8uiFkqxkcWndWi+W7bXdPbt27Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.48.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.48.1.tgz",
+      "integrity": "sha512-RUyZZ/mga88lMI3RlXFs4WQ7n3VyU07sPXmMG7/C1NOi8qisUg57Y7LRarqoGoAiopmGmChUhSwfpvQ3H5iGSQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.34.9.tgz",
+      "integrity": "sha512-AyleYRPU7+rgkMWbEh71fQlrzRfeP6SyMnRf9XX4fCdDPAJumdSBqYEcWPMzVQ4ScAl7E4oFfK0GUVn77xSwbw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/@sinclair/typebox": {
@@ -1104,9 +1815,9 @@
       }
     },
     "node_modules/@stencil/angular-output-target": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@stencil/angular-output-target/-/angular-output-target-1.1.0.tgz",
-      "integrity": "sha512-V1tlX2LgtioTHa6+W2enk+GNDyV0BhC5iH3fY5fc30l8MNNWiLm8yP7EfN3DbT8L7DHxrQeYkrvJJeG8IX7NSA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@stencil/angular-output-target/-/angular-output-target-1.1.1.tgz",
+      "integrity": "sha512-NMZjnbNi+gfUjlLRAWPLzwUuX1dGzkaIi/OqoVbElmZfxNI+kihZTW2EvDsA3SJx6bSJBsFNrIMx3tW9TQ3v6Q==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -1114,9 +1825,9 @@
       }
     },
     "node_modules/@stencil/core": {
-      "version": "4.36.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.36.1.tgz",
-      "integrity": "sha512-LRZN1c4X+9/7kR+zG74SrcZ6XxKlilDTkDXajw3ioeDdVlJEvW5wU8Wn3BcAAnk7fjrgLZVN7ickgeuG7u0AKg==",
+      "version": "4.36.3",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.36.3.tgz",
+      "integrity": "sha512-C9DOaAjm+hSYRuVoUuYWG/lrYT8+4DG0AL0m1Ea9+G5v2Y6ApVpNJLbXvFlRZIdDMGecH86s6v0Gp39uockLxg==",
       "license": "MIT",
       "bin": {
         "stencil": "bin/stencil"
@@ -1244,6 +1955,32 @@
         "path-browserify": "^1.0.1"
       }
     },
+    "node_modules/@ts-morph/common/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1280,14 +2017,20 @@
       }
     },
     "node_modules/@types/babel__traverse": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.7.tgz",
-      "integrity": "sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.20.7"
+        "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "license": "MIT"
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
@@ -1345,14 +2088,21 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.13.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.9.tgz",
-      "integrity": "sha512-acBjXdRJ3A6Pb3tqnw9HZmyR3Fiol3aGxRCK1x3d+6CDAMjl7I649wpSd+yNURCjbOUGu9tqtLKnTGxmK6CyGw==",
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
+      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~7.10.0"
       }
+    },
+    "node_modules/@types/resolve": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -1402,9 +2152,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1620,55 +2370,6 @@
         "webpack": ">=5.61.0"
       }
     },
-    "node_modules/babel-loader/node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/babel-loader/node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/babel-loader/node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/babel-plugin-istanbul": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
@@ -1720,9 +2421,9 @@
       }
     },
     "node_modules/babel-preset-current-node-syntax": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.1.1.tgz",
-      "integrity": "sha512-23fWKohMTvS5s0wwJKycOe0dBdCwQ6+iiLaNR9zy8P13mtFRFM9qLLX6HJX5DL2pi/FNDf3fCQHM4FIMoHH/7w==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1771,17 +2472,17 @@
       "license": "MIT"
     },
     "node_modules/bare-events": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.6.0.tgz",
-      "integrity": "sha512-EKZ5BTXYExaNqi3I3f9RtEsaI/xBSGjE0XZCZilPzFAV/goswFHuPd9jEZlPIZ/iNZJwDSao9qRiScySz7MbQg==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.6.1.tgz",
+      "integrity": "sha512-AuTJkq9XmE6Vk0FJVNq5QxETrSA/vKHarWVBG5l/JbdCL1prJemiyJqUS0jrlXO0MftuPq4m3YVYhoNc5+aE/g==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true
     },
     "node_modules/bare-fs": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.1.6.tgz",
-      "integrity": "sha512-25RsLF33BqooOEFNdMcEhMpJy8EoR88zSMrnOQOaM3USnOK2VmaJ1uaQEwPA6AQjrv1lXChScosN6CzbwbO9OQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.2.1.tgz",
+      "integrity": "sha512-mELROzV0IhqilFgsl1gyp48pnZsaV9xhQapHLDsvn4d4ZTfbFhcghQezl7FTEDNBcGqLUnNI3lUlm6ecrLWdFA==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -1803,9 +2504,9 @@
       }
     },
     "node_modules/bare-os": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.1.tgz",
-      "integrity": "sha512-uaIjxokhFidJP+bmmvKSgiMzj2sV5GPHaZVAIktcxcpCyBFFWO+YlikVAdhmUo2vYFvFhOXIAlldqV29L8126g==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz",
+      "integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -1825,9 +2526,9 @@
       }
     },
     "node_modules/bare-stream": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.6.5.tgz",
-      "integrity": "sha512-jSmxKJNJmHySi6hC42zlZnq00rga4jjxcgNZjY9N5WlOe/iOoGRtdwGsHzQv2RlH2KOYMwGUXhf2zXd32BA9RA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
+      "integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -1858,13 +2559,14 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/braces": {
@@ -1881,9 +2583,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.25.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
-      "integrity": "sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==",
+      "version": "4.25.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.3.tgz",
+      "integrity": "sha512-cDGv1kkDI4/0e5yON9yM5G/0A5u8sf5TnmdX5C9qHzI9PPu++sQ9zjm1k9NiOrf3riY4OkK0zSGqfvJyJsgCBQ==",
       "dev": true,
       "funding": [
         {
@@ -1901,8 +2603,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001726",
-        "electron-to-chromium": "^1.5.173",
+        "caniuse-lite": "^1.0.30001735",
+        "electron-to-chromium": "^1.5.204",
         "node-releases": "^2.0.19",
         "update-browserslist-db": "^1.1.3"
       },
@@ -1981,9 +2683,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001727",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
-      "integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
+      "version": "1.0.30001737",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001737.tgz",
+      "integrity": "sha512-BiloLiXtQNrY5UyF0+1nSJLXUENuhka2pzy2Fx5pGxqavdrxSCW4U6Pn/PoG3Efspi2frRbHpBV2XsrPE6EDlw==",
       "dev": true,
       "funding": [
         {
@@ -2037,10 +2739,27 @@
         "fuse.js": "^7.0.0"
       }
     },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/chromium-bidi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-7.2.0.tgz",
-      "integrity": "sha512-gREyhyBstermK+0RbcJLbFhcQctg92AGgDe/h/taMJEOLRdtSswBAO9KmvltFSQWgM2LrwWu5SIuEUbdm3JsyQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-8.0.0.tgz",
+      "integrity": "sha512-d1VmE0FD7lxZQHzcDUCKZSNRtRwISXDsdg4HjdTR5+Ll5nQ/vzU12JeNmupD6VWffrPSlrnGhEWlLESKH3VO+g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2160,6 +2879,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2183,9 +2909,9 @@
       "license": "MIT"
     },
     "node_modules/core-js-pure": {
-      "version": "3.44.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.44.0.tgz",
-      "integrity": "sha512-gvMQAGB4dfVUxpYD0k3Fq8J+n5bB6Ytl15lqlZrOIXFzxOhtPaObfkQGHtMRdyjIf7z2IeNULwi1jEwyS+ltKQ==",
+      "version": "3.45.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.45.1.tgz",
+      "integrity": "sha512-OHnWFKgTUshEU8MK+lOs1H8kC8GkTi9Z1tvNkxrCcw9wl3MJIO7q2ld77wjWn4/xuGrVu2X+nME1iIIPBSdyEQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "funding": {
@@ -2370,6 +3096,20 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "bin": {
+        "detect-libc": "bin/detect-libc.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -2381,9 +3121,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1464554",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1464554.tgz",
-      "integrity": "sha512-CAoP3lYfwAGQTaAXYvA6JZR0fjGUb7qec1qf4mToyoH2TZgUFeIqYcjh6f9jNuhHfuZiEdH+PONHYrLhRQX6aw==",
+      "version": "0.0.1475386",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1475386.tgz",
+      "integrity": "sha512-RQ809ykTfJ+dgj9bftdeL2vRVxASAuGU+I9LEx9Ij5TXU5HrgAQVmzi72VA+mkzscE12uzlRv5/tWWv9R9J1SA==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -2484,9 +3224,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.190",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.190.tgz",
-      "integrity": "sha512-k4McmnB2091YIsdCgkS0fMVMPOJgxl93ltFzaryXqwip1AaxeDqKCGLxkXODDA5Ab/D+tV5EL5+aTx76RvLRxw==",
+      "version": "1.5.208",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.208.tgz",
+      "integrity": "sha512-ozZyibehoe7tOhNaf16lKmljVf+3npZcJIEbJRVftVsmAg5TeA1mGS9dVCZzOwr2xT7xK15V0p7+GZqSPgkuPg==",
       "dev": true,
       "license": "ISC"
     },
@@ -2521,9 +3261,9 @@
       }
     },
     "node_modules/entities": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.0.tgz",
-      "integrity": "sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -2663,6 +3403,13 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -2846,6 +3593,24 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -2860,23 +3625,26 @@
       }
     },
     "node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "locate-path": "^5.0.0",
+        "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "funding": [
         {
           "type": "individual",
@@ -2920,7 +3688,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -3079,30 +3846,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -3172,9 +3915,9 @@
       }
     },
     "node_modules/html-dom-parser": {
-      "version": "5.0.13",
-      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.0.13.tgz",
-      "integrity": "sha512-B7JonBuAfG32I7fDouUQEogBrz3jK9gAuN1r1AaXpED6dIhtg/JwiSRhjGL7aOJwRz3HU4efowCjQBaoXiREqg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.1.1.tgz",
+      "integrity": "sha512-+o4Y4Z0CLuyemeccvGN4bAO20aauB2N9tFEAep5x4OW34kV4PTarBHm6RL02afYt2BMKcr0D2Agep8S3nJPIBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3190,16 +3933,16 @@
       "license": "MIT"
     },
     "node_modules/html-react-parser": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.2.2.tgz",
-      "integrity": "sha512-yA5012CJGSFWYZsgYzfr6HXJgDap38/AEP4ra8Cw+WHIi2ZRDXRX/QVYdumRf1P8zKyScKd6YOrWYvVEiPfGKg==",
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.2.6.tgz",
+      "integrity": "sha512-qcpPWLaSvqXi+TndiHbCa+z8qt0tVzjMwFGFBAa41ggC+ZA5BHaMIeMJla9g3VSp4SmiZb9qyQbmbpHYpIfPOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "domhandler": "5.0.3",
-        "html-dom-parser": "5.0.13",
+        "html-dom-parser": "5.1.1",
         "react-property": "2.0.2",
-        "style-to-js": "1.1.16"
+        "style-to-js": "1.1.17"
       },
       "peerDependencies": {
         "@types/react": "0.14 || 15 || 16 || 17 || 18 || 19",
@@ -3386,25 +4129,14 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      },
       "engines": {
         "node": ">= 12"
       }
-    },
-    "node_modules/ip-address/node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -3472,6 +4204,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -3480,6 +4219,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
       }
     },
     "node_modules/is-stream": {
@@ -3579,9 +4328,9 @@
       }
     },
     "node_modules/istanbul-reports": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
-      "integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4220,13 +4969,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsbn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -4316,16 +5058,19 @@
       "license": "MIT"
     },
     "node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "p-locate": "^4.1.0"
+        "p-locate": "^5.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lru-cache": {
@@ -4336,6 +5081,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.18",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.18.tgz",
+      "integrity": "sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/make-dir": {
@@ -4449,19 +5204,16 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^1.1.7"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": "*"
       }
     },
     "node_modules/mitt": {
@@ -4510,6 +5262,14 @@
       "engines": {
         "node": ">= 0.4.0"
       }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -4591,29 +5351,16 @@
       }
     },
     "node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "p-limit": "^2.2.0"
+        "p-limit": "^3.0.2"
       },
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/p-locate/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4795,6 +5542,62 @@
         "node": ">=8"
       }
     },
+    "node_modules/pkg-dir/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/prettier": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
@@ -4917,18 +5720,18 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "24.15.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.15.0.tgz",
-      "integrity": "sha512-HPSOTw+DFsU/5s2TUUWEum9WjFbyjmvFDuGHtj2X4YUz2AzOzvKMkT3+A3FR+E+ZefiX/h3kyLyXzWJWx/eMLQ==",
+      "version": "24.17.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.17.0.tgz",
+      "integrity": "sha512-CGrmJ8WgilK3nyE73k+pbxHggETPpEvL6AQ9H5JSK1RgZRGMQVJ+iO3MocGm9yBQXQJ9U5xijyLvkYXFeb0/+g==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.10.6",
-        "chromium-bidi": "7.2.0",
+        "@puppeteer/browsers": "2.10.7",
+        "chromium-bidi": "8.0.0",
         "cosmiconfig": "^9.0.0",
-        "devtools-protocol": "0.0.1464554",
-        "puppeteer-core": "24.15.0",
+        "devtools-protocol": "0.0.1475386",
+        "puppeteer-core": "24.17.0",
         "typed-query-selector": "^2.12.0"
       },
       "bin": {
@@ -4939,16 +5742,16 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "24.15.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.15.0.tgz",
-      "integrity": "sha512-2iy0iBeWbNyhgiCGd/wvGrDSo73emNFjSxYOcyAqYiagkYt5q4cPfVXaVDKBsukgc2fIIfLAalBZlaxldxdDYg==",
+      "version": "24.17.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.17.0.tgz",
+      "integrity": "sha512-RYOBKFiF+3RdwIZTEacqNpD567gaFcBAOKTT7742FdB1icXudrPI7BlZbYTYWK2wgGQUXt9Zi1Yn+D5PmCs4CA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.10.6",
-        "chromium-bidi": "7.2.0",
+        "@puppeteer/browsers": "2.10.7",
+        "chromium-bidi": "8.0.0",
         "debug": "^4.4.1",
-        "devtools-protocol": "0.0.1464554",
+        "devtools-protocol": "0.0.1475386",
         "typed-query-selector": "^2.12.0",
         "ws": "^8.18.3"
       },
@@ -5046,6 +5849,27 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT"
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -5131,6 +5955,149 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.48.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.48.1.tgz",
+      "integrity": "sha512-jVG20NvbhTYDkGAty2/Yh7HK6/q3DGSRH4o8ALKGArmMuaauM9kLfoMZ+WliPwA5+JHr2lTn3g557FxBV87ifg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.48.1",
+        "@rollup/rollup-android-arm64": "4.48.1",
+        "@rollup/rollup-darwin-arm64": "4.48.1",
+        "@rollup/rollup-darwin-x64": "4.48.1",
+        "@rollup/rollup-freebsd-arm64": "4.48.1",
+        "@rollup/rollup-freebsd-x64": "4.48.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.48.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.48.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.48.1",
+        "@rollup/rollup-linux-arm64-musl": "4.48.1",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.48.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.48.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.48.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.48.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.48.1",
+        "@rollup/rollup-linux-x64-gnu": "4.48.1",
+        "@rollup/rollup-linux-x64-musl": "4.48.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.48.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.48.1",
+        "@rollup/rollup-win32-x64-msvc": "4.48.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.48.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.48.1.tgz",
+      "integrity": "sha512-+XjmyChHfc4TSs6WUQGmVf7Hkg8ferMAE2aNYYWjiLzAS/T62uOsdfnqv+GHRjq7rKRnYh4mwWb4Hz7h/alp8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.48.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.48.1.tgz",
+      "integrity": "sha512-upGEY7Ftw8M6BAJyGwnwMw91rSqXTcOKZnnveKrVWsMTF8/k5mleKSuh7D4v4IV1pLxKAk3Tbs0Lo9qYmii5mQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.48.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.48.1.tgz",
+      "integrity": "sha512-Vy/WS4z4jEyvnJm+CnPfExIv5sSKqZrUr98h03hpAMbE2aI0aD2wvK6GiSe8Gx2wGp3eD81cYDpLLBqNb2ydwQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.48.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.48.1.tgz",
+      "integrity": "sha512-x5Kzn7XTwIssU9UYqWDB9VpLpfHYuXw5c6bJr4Mzv9kIv242vmJHbI5PJJEnmBYitUIfoMCODDhR7KoZLot2VQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.48.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.48.1.tgz",
+      "integrity": "sha512-90taWXCWxTbClWuMZD0DKYohY1EovA+W5iytpE89oUPmT5O1HFdf8cuuVIylE6vCbrGdIGv85lVRzTcpTRZ+kA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.48.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.48.1.tgz",
+      "integrity": "sha512-2Gu29SkFh1FfTRuN1GR1afMuND2GKzlORQUP3mNMJbqdndOg7gNsa81JnORctazHRokiDzQ5+MLE5XYmZW5VWg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.48.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.48.1.tgz",
+      "integrity": "sha512-6kQFR1WuAO50bxkIlAVeIYsz3RUx+xymwhTo9j94dJ+kmHe9ly7muH23sdfWduD0BA8pD9/yhonUvAjxGh34jQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.48.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.48.1.tgz",
+      "integrity": "sha512-8a/caCUN4vkTChxkaIJcMtwIVcBhi4X2PQRoT+yCK3qRYaZ7cURrmJFL5Ux9H9RaMIXj9RuihckdmkBX3zZsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5171,10 +6138,32 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
+    "node_modules/sass": {
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.90.0.tgz",
+      "integrity": "sha512-9GUyuksjw70uNpb1MTYWsH9MQHOHY6kwfnkafC24+7aOMZn9+rVMBxRbLvw756mrBFbIsFg6Xw9IkR2Fnn3k+Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "chokidar": "^4.0.0",
+        "immutable": "^5.0.2",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher": "^2.4.1"
+      }
+    },
     "node_modules/sass-embedded": {
-      "version": "1.89.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.89.2.tgz",
-      "integrity": "sha512-Ack2K8rc57kCFcYlf3HXpZEJFNUX8xd8DILldksREmYXQkRHI879yy8q4mRDJgrojkySMZqmmmW1NxrFxMsYaA==",
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.90.0.tgz",
+      "integrity": "sha512-XP1EltyLLfuU5FsGVjSz8PcT925oA3rDnJTWOEBHR42k62ZEbKTcZ4gVlFwKi0Ggzi5E8v1K2BplD8ELHwusYg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5194,28 +6183,115 @@
         "node": ">=16.0.0"
       },
       "optionalDependencies": {
-        "sass-embedded-android-arm": "1.89.2",
-        "sass-embedded-android-arm64": "1.89.2",
-        "sass-embedded-android-riscv64": "1.89.2",
-        "sass-embedded-android-x64": "1.89.2",
-        "sass-embedded-darwin-arm64": "1.89.2",
-        "sass-embedded-darwin-x64": "1.89.2",
-        "sass-embedded-linux-arm": "1.89.2",
-        "sass-embedded-linux-arm64": "1.89.2",
-        "sass-embedded-linux-musl-arm": "1.89.2",
-        "sass-embedded-linux-musl-arm64": "1.89.2",
-        "sass-embedded-linux-musl-riscv64": "1.89.2",
-        "sass-embedded-linux-musl-x64": "1.89.2",
-        "sass-embedded-linux-riscv64": "1.89.2",
-        "sass-embedded-linux-x64": "1.89.2",
-        "sass-embedded-win32-arm64": "1.89.2",
-        "sass-embedded-win32-x64": "1.89.2"
+        "sass-embedded-all-unknown": "1.90.0",
+        "sass-embedded-android-arm": "1.90.0",
+        "sass-embedded-android-arm64": "1.90.0",
+        "sass-embedded-android-riscv64": "1.90.0",
+        "sass-embedded-android-x64": "1.90.0",
+        "sass-embedded-darwin-arm64": "1.90.0",
+        "sass-embedded-darwin-x64": "1.90.0",
+        "sass-embedded-linux-arm": "1.90.0",
+        "sass-embedded-linux-arm64": "1.90.0",
+        "sass-embedded-linux-musl-arm": "1.90.0",
+        "sass-embedded-linux-musl-arm64": "1.90.0",
+        "sass-embedded-linux-musl-riscv64": "1.90.0",
+        "sass-embedded-linux-musl-x64": "1.90.0",
+        "sass-embedded-linux-riscv64": "1.90.0",
+        "sass-embedded-linux-x64": "1.90.0",
+        "sass-embedded-unknown-all": "1.90.0",
+        "sass-embedded-win32-arm64": "1.90.0",
+        "sass-embedded-win32-x64": "1.90.0"
+      }
+    },
+    "node_modules/sass-embedded-all-unknown": {
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-all-unknown/-/sass-embedded-all-unknown-1.90.0.tgz",
+      "integrity": "sha512-/n7jTQvI+hftDDrHzK19G4pxfDzOhtjuQO1K54ui1pT2S0sWfWDjCYUbQgtWQ6FO7g5qWS0hgmrWdc7fmS3rgA==",
+      "cpu": [
+        "!arm",
+        "!arm64",
+        "!riscv64",
+        "!x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "sass": "1.90.0"
+      }
+    },
+    "node_modules/sass-embedded-android-arm": {
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.90.0.tgz",
+      "integrity": "sha512-usF6kVJQWa1CMgPH1nCT1y8KEmAT2fzB00dDIPBYHq8U5VZLCihi2bJRP5U9NlcwP1TlKGKCjwsbIdSjDKfecg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-android-arm64": {
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.90.0.tgz",
+      "integrity": "sha512-bkTlewzWksa6Sj4Zs1CWiutnvUbsO3xuYh2QBRknXsOtuMlfTPoXnwhCnyE4lSvUxw2qxSbv+NdQev9qMfsBgA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-android-riscv64": {
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-riscv64/-/sass-embedded-android-riscv64-1.90.0.tgz",
+      "integrity": "sha512-bpqCIOaX+0Lou/BNJ4iJIKbWbVaYXFdg26C3gG6gxxKZRzp/6OYCxHrIQDwhKz6YC8Q5rwNPMpfDVYbWPcgroA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-android-x64": {
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.90.0.tgz",
+      "integrity": "sha512-GNxVKnCMd/p2icZ+Q4mhvNk19NrLXq1C4guiqjrycHYQLEnxRkjbW1QXYiL+XyDn4e+Bcq0knzG0I9pMuNZxkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/sass-embedded-darwin-arm64": {
-      "version": "1.89.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.89.2.tgz",
-      "integrity": "sha512-UCm3RL/tzMpG7DsubARsvGUNXC5pgfQvP+RRFJo9XPIi6elopY5B6H4m9dRYDpHA+scjVthdiDwkPYr9+S/KGw==",
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.90.0.tgz",
+      "integrity": "sha512-qr4KBMJfBA+lzXiWnP00qzpLzHQzGd1OSK3VHcUFjZ8l7VOYf2R7Tc3fcTLhpaNPMJtTK0jrk8rFqBvsiZExnA==",
       "cpu": [
         "arm64"
       ],
@@ -5224,6 +6300,210 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-darwin-x64": {
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.90.0.tgz",
+      "integrity": "sha512-z2nr1nNqtWDLVRwTbHtL7zriK90U7O/Gb15UaCSMYeAz9Y+wog5s/sDEKm0+GsVdzzkaCaMZRWGN4jTilnUwmQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-arm": {
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.90.0.tgz",
+      "integrity": "sha512-FeBxI5Q2HvM3CCadcEcQgvWbDPVs2YEF0PZ87fbAVTCG8dV+iNnQreSz7GRJroknpvbRhm5t2gedvcgmTnPb2Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-arm64": {
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.90.0.tgz",
+      "integrity": "sha512-SPMcGZuP71Fj8btCGtlBnv8h8DAbJn8EQfLzXs9oo6NGFFLVjNGiFpqGfgtUV6DLWCuaRyEFeViO7wZow/vKGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-musl-arm": {
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.90.0.tgz",
+      "integrity": "sha512-EB2z0fUXdUdvSoddf4DzdZQkD/xyreD72gwAi8YScgUvR4HMXI7bLcK/n78Rft6OnqvV8090hjC8FsLDo3x5xQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-musl-arm64": {
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.90.0.tgz",
+      "integrity": "sha512-xLH7+PFq763MoEm3vI7hQk5E+nStiLWbijHEYW/tEtCbcQIphgzSkDItEezxXew3dU4EJ1jqrBUySPdoXFLqWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-musl-riscv64": {
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.90.0.tgz",
+      "integrity": "sha512-L21UkOgnSrD+ERF+jo1IWneGv40t0ap9+3cI+wZWYhQS5MkxponhT9QaNU57JEDJwB9mOl01LVw14opz4SN+VQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-musl-x64": {
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.90.0.tgz",
+      "integrity": "sha512-NeAycQlsdhFdnIeSmRmScYUyCd+uE+x15NLFunbF8M0PgCKurrUhaxgGKSuBbaK56FpxarKOHCqcOrWbemIGzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-riscv64": {
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.90.0.tgz",
+      "integrity": "sha512-lJopaQhW8S+kaQ61vMqq3c+bOurcf9RdZf2EmzQYpc2y1vT5cWfRNrRkbAgO/23IQxsk/fq3UIUnsjnyQmi6MA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-x64": {
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.90.0.tgz",
+      "integrity": "sha512-Cc061gBfMPwH9rN7neQaH36cvOQC+dFMSGIeX5qUOhrEL4Ng51iqBV6aI4RIB1jCFGth6eDydVRN1VdV9qom8A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-unknown-all": {
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-unknown-all/-/sass-embedded-unknown-all-1.90.0.tgz",
+      "integrity": "sha512-DBGzHVCJDqtjTHZFohush9YTxd4ZxhIygIRTNRXnA0359woF9Z8AS7/YxfzwkqrTX5durSJa6ZamGFYVLoRphQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "!android",
+        "!darwin",
+        "!linux",
+        "!win32"
+      ],
+      "dependencies": {
+        "sass": "1.90.0"
+      }
+    },
+    "node_modules/sass-embedded-win32-arm64": {
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.90.0.tgz",
+      "integrity": "sha512-c3/vL/CATnaW3x/6kcNbCROEOUU7zvJpIURp7M9664GJj08/gLPRWKNruw0OkAPQ3C5TTQz7+/fQWEpRA6qmvA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-win32-x64": {
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.90.0.tgz",
+      "integrity": "sha512-PFwdW7AYtCkwi3NfWFeexvIZEJ0nuShp8Bjjc3px756+18yYwBWa78F4TGdIQmJfpYKBhgkVjFOctwq+NCHntA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=14.0.0"
@@ -5246,9 +6526,9 @@
       }
     },
     "node_modules/schema-utils": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
-      "integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.2.tgz",
+      "integrity": "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5350,13 +6630,13 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.6.tgz",
-      "integrity": "sha512-pe4Y2yzru68lXCb38aAqRf5gvN8YdjP1lok5o0J7BOHljkyCGKVz7H3vpVIXKD27rj2giOJ7DwVyk/GWrPHDWA==",
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^9.0.5",
+        "ip-address": "^10.0.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -5391,6 +6671,17 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5525,19 +6816,19 @@
       }
     },
     "node_modules/style-to-js": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.16.tgz",
-      "integrity": "sha512-/Q6ld50hKYPH3d/r6nr117TZkHR0w0kGGIVfpG9N6D8NymRPM9RqCUv4pRpJ62E5DqOYx2AFpbZMyCPnjQCnOw==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.17.tgz",
+      "integrity": "sha512-xQcBGDxJb6jjFCTzvQtfiPn6YvvP2O8U1MDIPNfJQlWMYfktPy+iGsHE7cssjs7y84d9fQaK4UF3RIJaAHSoYA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "style-to-object": "1.0.8"
+        "style-to-object": "1.0.9"
       }
     },
     "node_modules/style-to-object": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.8.tgz",
-      "integrity": "sha512-xT47I/Eo0rwJmaXC4oilDGDWLohVhR6o/xAQcPQN8q6QBuZVL8qMYL85kLmST5cPjAorwvqIA4qXTRQoYHaL6g==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.9.tgz",
+      "integrity": "sha512-G4qppLgKu/k6FwRpHiGiKPaPTFcG3g4wNVX/Qsfu+RqQM30E7Tyu/TEgxcL9PNLF5pdRLwQdE3YKKf+KF2Dzlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5621,14 +6912,14 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.0.tgz",
-      "integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
+      "version": "5.43.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.43.1.tgz",
+      "integrity": "sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.8.2",
+        "acorn": "^8.14.0",
         "commander": "^2.20.0",
         "source-map-support": "~0.5.20"
       },
@@ -5731,30 +7022,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/text-decoder": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
@@ -5766,17 +7033,17 @@
       }
     },
     "node_modules/tinybase": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/tinybase/-/tinybase-6.5.1.tgz",
-      "integrity": "sha512-/NDdP0jwD6kgzuhZpMhxDlH8st3AD3VmUh5ifIBUggec9QXCkorM/SQ3ggNZGv9SxjKGEilS7hpQzWVpNTmPRQ==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/tinybase/-/tinybase-6.5.2.tgz",
+      "integrity": "sha512-egWlEZSyG3+qhov+l/W6A/VgXQ28jHSfXpFr25UGVxdQB8Mn9qtJjC5Avey/QY0K7v4qAt1rJccSO0XQJ0Y93A==",
       "license": "MIT",
       "peerDependencies": {
         "@automerge/automerge-repo": "^1.2.1",
-        "@cloudflare/workers-types": "^4.20250806.0",
+        "@cloudflare/workers-types": "^4.20250813.0",
         "@electric-sql/pglite": "^0.2.17",
         "@libsql/client": "^0.15.10",
-        "@powersync/common": "^1.35.0",
-        "@sqlite.org/sqlite-wasm": "^3.50.3-build1",
+        "@powersync/common": "^1.36.0",
+        "@sqlite.org/sqlite-wasm": "^3.50.4-build1",
         "@vlcn.io/crsqlite-wasm": "^0.16.0",
         "bun": "^1.2.19",
         "electric-sql": "^0.12.1",
@@ -5928,9 +7195,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -5942,9 +7209,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
       "dev": true,
       "license": "MIT"
     },

--- a/verdocs-web-sdk/package.json
+++ b/verdocs-web-sdk/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "push": "npm run build && npm publish",
     "build": "stencil build --docs",
+    "postbuild": "node ../fix-angular-proxies.js",
     "serve": "stencil build --dev --watch --serve",
     "start": "stencil build --dev --watch --docs",
     "test": "stencil test --spec",
@@ -46,7 +47,7 @@
   "devDependencies": {
     "@babel/core": "^7.28.0",
     "@interactjs/types": "^1.10.27",
-    "@stencil/angular-output-target": "^1.1.0",
+    "@stencil/angular-output-target": "^1.1.1",
     "@stencil/react-output-target": "^1.2.0",
     "@stencil/sass": "^3.2.2",
     "@stencil/vue-output-target": "^0.10.8",

--- a/verdocs-web-sdk/package.json
+++ b/verdocs-web-sdk/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@verdocs/web-sdk",
   "version": "6.0.4",
   "private": false,
@@ -18,7 +19,8 @@
   ],
   "scripts": {
     "push": "npm run build && npm publish",
-    "build": "stencil build --docs",
+    "build": "stencil build --docs && npm run build-vanilla",
+    "build-vanilla": "rollup -c rollup.config.mjs",
     "postbuild": "node ../fix-angular-proxies.js",
     "serve": "stencil build --dev --watch --serve",
     "start": "stencil build --dev --watch --docs",
@@ -40,6 +42,7 @@
     "imask": "^7.6.1",
     "interactjs": "^1.10.27",
     "jszip": "^3.10.1",
+    "rollup": "^4.48.1",
     "sortablejs": "^1.15.6",
     "tinybase": "^6.5.1",
     "workflow-svg.js": "^3.0.2"
@@ -47,6 +50,8 @@
   "devDependencies": {
     "@babel/core": "^7.28.0",
     "@interactjs/types": "^1.10.27",
+    "@rollup/plugin-commonjs": "^28.0.6",
+    "@rollup/plugin-node-resolve": "^16.0.1",
     "@stencil/angular-output-target": "^1.1.1",
     "@stencil/react-output-target": "^1.2.0",
     "@stencil/sass": "^3.2.2",

--- a/verdocs-web-sdk/rollup.config.mjs
+++ b/verdocs-web-sdk/rollup.config.mjs
@@ -1,0 +1,24 @@
+// Rollup config for bundling vanilla-bundle.js into a single IIFE for CDN/Vanilla JS usage
+
+import resolve from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+
+export default {
+  input: 'bundle-entry.js',
+  output: {
+    file: 'dist/verdocs-web-sdk-vanilla.js',
+    format: 'iife',
+    name: 'VerdocsWebSDK',
+    inlineDynamicImports: true,
+    globals: {
+      '@verdocs/js-sdk': 'VerdocsJsSdk'
+    }
+  },
+  external: [
+    '@verdocs/js-sdk'
+  ],
+  plugins: [
+    resolve(),
+    commonjs()
+  ]
+};

--- a/verdocs-web-sdk/src/components/envelopes/verdocs-envelope-sidebar/verdocs-envelope-sidebar.tsx
+++ b/verdocs-web-sdk/src/components/envelopes/verdocs-envelope-sidebar/verdocs-envelope-sidebar.tsx
@@ -192,7 +192,7 @@ export class VerdocsEnvelopeSidebar {
         break;
 
       case 'reminder':
-        resendInvitation(this.endpoint, this.envelopeId, recipient.role_name)
+        resendInvitation(this.endpoint, this.envelopeId, recipient.role_name, "reminder")
           .then(() => {
             VerdocsToast('Reminder Sent', {style: 'success'});
           })

--- a/verdocs-web-sdk/stencil.config.ts
+++ b/verdocs-web-sdk/stencil.config.ts
@@ -59,14 +59,11 @@ export const config: Config = {
     },
     {
       type: 'dist-custom-elements',
-      customElementsExportBehavior: 'bundle',
-      // customElementsExportBehavior: 'auto-define-custom-elements',
+      // customElementsExportBehavior: 'bundle',
+      customElementsExportBehavior: 'auto-define-custom-elements',
       generateTypeDeclarations: true,
       externalRuntime: false,
     },
-    // {
-    //   type: 'dist-custom-elements-bundle',
-    // },
     // We actually don't need these docs, we want Storybook to use "inline" docs instead. But commenting out this block
     // didn't appear to actually disable their generation. Overriding the target directory gets them out of the way so
     // storybook can do its job.

--- a/verdocs-web-sdk/stencil.config.ts
+++ b/verdocs-web-sdk/stencil.config.ts
@@ -40,6 +40,7 @@ export const config: Config = {
       componentCorePackage: '@verdocs/web-sdk',
       directivesProxyFile: '../verdocs-web-sdk-angular/src/directives/proxies.ts',
       valueAccessorConfigs: angularValueAccessorBindings,
+      customElementsDir: 'dist/components',
     }),
     reactOutputTarget({
       outDir: '../verdocs-web-sdk-react/src',


### PR DESCRIPTION
- fix vue build target 
- add vanilla JS build target and update doc (vanilla JS build is created in dist/verdocs-web-sdk-vanilla.js) @crrobinson14 please verify if this is correct as I have added a rollup bundle step after npm run build in verdocs-web-sdk subfolder. 
- fix angular target