### PR TITLE
Replaced location.reload functionality in verdocs-sign

### DIFF
--- a/verdocs-web-sdk/src/components/embeds/verdocs-sign/verdocs-sign.spec.tsx
+++ b/verdocs-web-sdk/src/components/embeds/verdocs-sign/verdocs-sign.spec.tsx
@@ -1,12 +1,426 @@
-import { newSpecPage } from '@stencil/core/testing';
-import { VerdocsSign } from './verdocs-sign';
+jest.mock('tinybase', () => {
+  const rows: Record<string, Record<string, unknown>> = {};
+
+  const createMockStore = () => ({
+    delTables: () => {
+      Object.keys(rows).forEach(key => delete rows[key]);
+    },
+    delValues: () => {},
+    hasRow: (tableId: string, rowId: string) => !!rows[`${tableId}:${rowId}`],
+    getRow: (tableId: string, rowId: string) => rows[`${tableId}:${rowId}`] || {},
+    setRow: (tableId: string, rowId: string, row: Record<string, unknown>) => {
+      rows[`${tableId}:${rowId}`] = row;
+    },
+    addRowListener: (_tableId: string, _rowId: string, _callback: () => void) => 'listener-id',
+    delListener: (_listenerId: string) => {},
+  });
+
+  return {
+    createStore: createMockStore,
+    Row: class {},
+  };
+});
+
+jest.mock('../../../utils/Toast', () => ({
+  VerdocsToast: jest.fn(),
+}));
+
+jest.mock('@verdocs/js-sdk', () => {
+  const actualSdk = jest.requireActual('@verdocs/js-sdk');
+
+  class FakeEndpoint {
+    static getDefault() {
+      return new FakeEndpoint();
+    }
+
+    api = {
+      get: jest.fn().mockResolvedValue({}),
+      post: jest.fn().mockResolvedValue({}),
+      put: jest.fn().mockResolvedValue({}),
+      delete: jest.fn().mockResolvedValue({}),
+    };
+
+    profile = {};
+    session = {};
+
+    loadSession() {}
+
+    onSessionChanged() {}
+
+    setTimeout() {}
+
+    setBaseURL() {}
+
+    getBaseURL() {
+      return '';
+    }
+  }
+
+  return {
+    ...actualSdk,
+    VerdocsEndpoint: FakeEndpoint,
+    startSigningSession: jest.fn(),
+    getEnvelope: jest.fn(),
+    envelopeRecipientSubmit: jest.fn(),
+    envelopeRecipientAgree: jest.fn(),
+    envelopeRecipientDecline: jest.fn(),
+  };
+});
+
+import {newSpecPage} from '@stencil/core/testing';
+import {envelopeRecipientSubmit, getEnvelope, ISignerTokenResponse, startSigningSession} from '@verdocs/js-sdk';
+import {VerdocsSign} from './verdocs-sign';
+
+const mockRecipient = {
+  role_name: 'Recipient 1',
+  status: 'opened',
+  agreed: false,
+  auth_step: null,
+};
+
+const mockEnvelope = {
+  id: 'env-1',
+  name: 'Test Envelope',
+  status: 'sent',
+  fields: [
+    {
+      name: 'signature-1',
+      type: 'signature',
+      role_name: 'Recipient 1',
+      document_id: 'doc-1',
+      page: 1,
+      required: true,
+      value: 'sig-id',
+      readonly: false,
+    },
+  ],
+  documents: [
+    {
+      id: 'doc-1',
+      name: 'Contract.pdf',
+      type: 'attachment',
+      pages: 1,
+      order: 1,
+      created_at: '2024-01-01T00:00:00.000Z',
+      page_sizes: {
+        1: {width: 612, height: 792},
+      },
+    },
+  ],
+  organization: {},
+  recipients: [mockRecipient],
+};
+
+const mockSessionResponse = {
+  access_token: 'test-token',
+  envelope: mockEnvelope,
+  recipient: mockRecipient,
+  brand: null,
+} as unknown as ISignerTokenResponse;
+
+interface CreatePageOptions {
+  envelopeId?: string;
+  roleId?: string;
+  inviteCode?: string;
+}
+
+const createPage = async (options: CreatePageOptions = {}) => {
+  const envelopeId = options.envelopeId ?? '';
+  const roleId = options.roleId ?? '';
+  const inviteCode = options.inviteCode ?? '';
+
+  return newSpecPage({
+    components: [VerdocsSign],
+    html: `<verdocs-sign envelope-id="${envelopeId}" role-id="${roleId}" invite-code="${inviteCode}"></verdocs-sign>`,
+  });
+};
+
+const loadInstance = async (overrides: Partial<typeof mockRecipient> = {}) => {
+  const page = await createPage({
+    envelopeId: 'env-1',
+    roleId: 'role-1',
+    inviteCode: 'invite-1',
+  });
+  const instance = page.rootInstance as VerdocsSign;
+
+  instance.processAuthResponse({
+    ...mockSessionResponse,
+    recipient: {...mockRecipient, ...overrides} as ISignerTokenResponse['recipient'],
+  });
+
+  return {page, instance};
+};
+
+const loadSigningView = async () => {
+  const {page, instance} = await loadInstance();
+
+  instance.agreed = true;
+  await page.waitForChanges();
+
+  return {page, instance};
+};
 
 describe('verdocs-sign', () => {
-  it('renders without crashing', async () => {
-    const page = await newSpecPage({
-      components: [VerdocsSign],
-      html: '<verdocs-sign></verdocs-sign>',
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (startSigningSession as jest.Mock).mockResolvedValue(mockSessionResponse);
+    (getEnvelope as jest.Mock).mockResolvedValue(mockEnvelope);
+    (envelopeRecipientSubmit as jest.Mock).mockResolvedValue({});
+
+    global.IntersectionObserver = class {
+      observe() {}
+
+      disconnect() {}
+
+      unobserve() {}
+    } as any;
+  });
+
+  describe('componentDidLoad', () => {
+    it('emits sdkError when envelopeId is missing', async () => {
+      const page = await createPage();
+      const instance = page.rootInstance as VerdocsSign;
+      const sdkErrorSpy = jest.spyOn(instance.sdkError, 'emit');
+
+      instance.roleId = 'role-1';
+      instance.inviteCode = 'invite-1';
+      await instance.componentDidLoad();
+
+      const expected = '[SIGN] Missing required envelopId';
+
+      expect(sdkErrorSpy.mock.calls[0][0].message).toBe(expected);
+      expect(startSigningSession).not.toHaveBeenCalled();
+      expect(instance.showLoadError).toBe(false);
     });
-    expect(page.root).toBeTruthy();
+
+    it('shows the load error dialog when signing session initialization fails', async () => {
+      (startSigningSession as jest.Mock).mockRejectedValue(new Error('Invalid invite'));
+      const page = await createPage({
+        envelopeId: 'env-1',
+        roleId: 'role-1',
+        inviteCode: 'bad-invite',
+      });
+      const instance = page.rootInstance as VerdocsSign;
+      const expected = 'Unable to Start Signing';
+
+      await page.waitForChanges();
+
+      expect(instance.showLoadError).toBe(true);
+      expect(page.root.querySelector('verdocs-ok-dialog')?.getAttribute('heading')).toBe(expected);
+    });
+
+    it('initializes the signing session when required props are provided', async () => {
+      const page = await createPage({
+        envelopeId: 'env-1',
+        roleId: 'role-1',
+        inviteCode: 'invite-1',
+      });
+      const instance = page.rootInstance as VerdocsSign;
+
+      await page.waitForChanges();
+
+      const expected = {
+        callCount: 1,
+        envelopeName: mockEnvelope.name,
+      };
+
+      expect(startSigningSession).toHaveBeenCalledTimes(expected.callCount);
+      expect(instance.envelope?.name).toBe(expected.envelopeName);
+    });
+  });
+
+  describe('retrySigningSession', () => {
+    it('retries session initialization after a load error', async () => {
+      (startSigningSession as jest.Mock)
+        .mockRejectedValueOnce(new Error('Invalid invite'))
+        .mockResolvedValueOnce(mockSessionResponse);
+
+      const page = await createPage({
+        envelopeId: 'env-1',
+        roleId: 'role-1',
+        inviteCode: 'invite-1',
+      });
+      const instance = page.rootInstance as VerdocsSign;
+
+      await page.waitForChanges();
+      await instance.retrySigningSession();
+      await page.waitForChanges();
+
+      const expected = {
+        callCount: 2,
+        showLoadError: false,
+        envelopeName: mockEnvelope.name,
+      };
+
+      expect(startSigningSession).toHaveBeenCalledTimes(expected.callCount);
+      expect(instance.showLoadError).toBe(expected.showLoadError);
+      expect(instance.envelope?.name).toBe(expected.envelopeName);
+    });
+  });
+
+  describe('processAuthResponse', () => {
+    it('enters the done view when the recipient has already submitted', async () => {
+      const page = await createPage();
+      const instance = page.rootInstance as VerdocsSign;
+
+      instance.processAuthResponse({
+        ...mockSessionResponse,
+        recipient: {...mockRecipient, status: 'submitted'} as ISignerTokenResponse['recipient'],
+      });
+      await page.waitForChanges();
+
+      const expected = {
+        submitted: true,
+        isDone: true,
+        showDone: true,
+      };
+
+      expect(instance.submitted).toBe(expected.submitted);
+      expect(instance.isDone).toBe(expected.isDone);
+      expect(instance.showDone).toBe(expected.showDone);
+      expect(page.root.querySelector('verdocs-view')).toBeTruthy();
+    });
+  });
+
+  describe('handleSubmitSuccess', () => {
+    it('marks the recipient as submitted and shows the done dialog', async () => {
+      const {instance} = await loadInstance();
+      const envelopeUpdatedSpy = jest.spyOn(instance.envelopeUpdated, 'emit');
+
+      await instance.handleSubmitSuccess();
+
+      const expected = {
+        submitted: true,
+        showDone: true,
+        nextSubmits: false,
+        signingProgressMode: 'completed',
+        event: 'submitted',
+      };
+
+      expect(instance.submitted).toBe(expected.submitted);
+      expect(instance.showDone).toBe(expected.showDone);
+      expect(instance.nextSubmits).toBe(expected.nextSubmits);
+      expect(instance.signingProgressMode).toBe(expected.signingProgressMode);
+      expect(envelopeUpdatedSpy.mock.calls[0][0].event).toBe(expected.event);
+    });
+
+    it('still shows the done dialog when refreshing the envelope fails', async () => {
+      (getEnvelope as jest.Mock).mockRejectedValue(new Error('Network error'));
+      const {instance} = await loadInstance();
+
+      await instance.handleSubmitSuccess();
+
+      const expected = {
+        submitted: true,
+        showDone: true,
+      };
+
+      expect(instance.submitted).toBe(expected.submitted);
+      expect(instance.showDone).toBe(expected.showDone);
+    });
+  });
+
+  describe('handleDoneDialogDismiss', () => {
+    it('transitions into the done view after the dialog is dismissed', async () => {
+      const {page, instance} = await loadSigningView();
+
+      instance.submitted = true;
+      instance.showDone = true;
+      await page.waitForChanges();
+
+      await instance.handleDoneDialogDismiss();
+
+      const expected = {
+        showDone: false,
+        isDone: true,
+      };
+
+      expect(instance.showDone).toBe(expected.showDone);
+      expect(instance.isDone).toBe(expected.isDone);
+    });
+  });
+
+  describe('checkRecipientFields', () => {
+    it('does not re-enable the finish button after submission', async () => {
+      const {instance} = await loadInstance();
+
+      instance.submitted = true;
+      instance.nextSubmits = false;
+      instance.nextButtonLabel = 'Next';
+      instance.checkRecipientFields();
+
+      const expected = {
+        nextSubmits: false,
+        nextButtonLabel: 'Next',
+      };
+
+      expect(instance.nextSubmits).toBe(expected.nextSubmits);
+      expect(instance.nextButtonLabel).toBe(expected.nextButtonLabel);
+    });
+  });
+
+  describe('handleNext', () => {
+    it('does not submit again when the recipient is already submitted', async () => {
+      const {instance} = await loadInstance();
+
+      instance.nextSubmits = true;
+      instance.submitted = true;
+      await instance.handleNext();
+
+      const expected = 0;
+
+      expect(envelopeRecipientSubmit).toHaveBeenCalledTimes(expected);
+    });
+
+    it('submits the envelope when finish is clicked', async () => {
+      const {instance} = await loadInstance();
+
+      instance.nextSubmits = true;
+      await instance.handleNext();
+
+      const expected = {
+        submitCallCount: 1,
+        submitted: true,
+        showDone: true,
+      };
+
+      expect(envelopeRecipientSubmit).toHaveBeenCalledTimes(expected.submitCallCount);
+      expect(instance.submitted).toBe(expected.submitted);
+      expect(instance.showDone).toBe(expected.showDone);
+    });
+  });
+
+  describe('render', () => {
+    it('renders the disclosure dialog before the recipient agrees', async () => {
+      const {page} = await loadInstance();
+      await page.waitForChanges();
+
+      const expected = 1;
+
+      expect(page.root.querySelectorAll('verdocs-disclosure-dialog').length).toBe(expected);
+    });
+
+    it('hides the finish button after submission', async () => {
+      const {page, instance} = await loadSigningView();
+
+      instance.toolbarStyle = 'menu';
+      instance.submitted = true;
+      await page.waitForChanges();
+
+      const expected = 0;
+
+      expect(page.root.querySelectorAll('verdocs-button').length).toBe(expected);
+    });
+
+    it('hides the sign footer after submission', async () => {
+      const {page, instance} = await loadSigningView();
+
+      instance.submitted = true;
+      await page.waitForChanges();
+
+      const expected = 0;
+
+      expect(page.root.querySelectorAll('verdocs-sign-footer').length).toBe(expected);
+    });
   });
 });

--- a/verdocs-web-sdk/src/components/embeds/verdocs-sign/verdocs-sign.tsx
+++ b/verdocs-web-sdk/src/components/embeds/verdocs-sign/verdocs-sign.tsx
@@ -171,17 +171,77 @@ export class VerdocsSign {
     }
 
     try {
-      console.log(`[SIGN] Processing invite code for ${this.envelopeId} / ${this.roleId}`);
-
-      // NOTE: We don't listen to the store here because we are often an independent
-      // session and might have a different "view" of the envelope.
-      const response = await startSigningSession(this.endpoint, this.envelopeId, this.roleId, this.inviteCode);
-      this.processAuthResponse(response);
+      await this.initSigningSession();
     } catch (e) {
       console.log('[SIGN] Error with signing session', e);
       this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
       this.showLoadError = true;
     }
+  }
+
+  async initSigningSession() {
+    console.log(`[SIGN] Processing invite code for ${this.envelopeId} / ${this.roleId}`);
+
+    // NOTE: We don't listen to the store here because we are often an independent
+    // session and might have a different "view" of the envelope.
+    const response = await startSigningSession(this.endpoint, this.envelopeId, this.roleId, this.inviteCode);
+    this.processAuthResponse(response);
+  }
+
+  async retrySigningSession() {
+    this.showLoadError = false;
+    this.loading = true;
+
+    try {
+      await this.initSigningSession();
+    } catch (e) {
+      console.log('[SIGN] Error with signing session', e);
+      this.sdkError?.emit(new SDKError(e.message, e.response?.status, e.response?.data));
+      this.showLoadError = true;
+      this.loading = false;
+    }
+  }
+
+  prepareForViewTransition() {
+    this.stopPolling();
+    this.observer?.disconnect();
+    this.observer = null;
+    document.getElementById('air-datepicker-global-container')?.remove();
+    document.getElementById('verdocs-sign-header')?.remove();
+  }
+
+  handleDoneDialogDismiss = async () => {
+    this.showDone = false;
+
+    if (!this.isDone) {
+      this.prepareForViewTransition();
+      await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+      this.isDone = true;
+    }
+  };
+
+  async handleSubmitSuccess() {
+    this.submitting = false;
+    this.submitted = true;
+    this.nextSubmits = false;
+    this.signingProgressMode = 'completed';
+
+    try {
+      const envelope = await getEnvelope(this.endpoint, this.envelopeId);
+      this.envelope = envelope;
+      Store.updateEnvelope(this.envelopeId, envelope);
+
+      const updatedRecipient = envelope.recipients?.find(r => r.role_name === this.recipient?.role_name);
+      if (updatedRecipient) {
+        this.recipient = updatedRecipient;
+      }
+
+      this.envelopeUpdated?.emit({endpoint: this.endpoint, envelope, event: 'submitted'});
+    } catch (e) {
+      console.warn('[SIGN] Error refreshing envelope after submit', e);
+    }
+
+    this.showDone = true;
   }
 
   componentDidRender() {
@@ -680,6 +740,10 @@ export class VerdocsSign {
 
   async handleNext() {
     if (this.nextSubmits) {
+      if (this.submitted) {
+        return;
+      }
+
       try {
         // Patches the date picker to be forcibly removed if still showing during submission
         document.getElementById('air-datepicker-global-container')?.remove();
@@ -689,10 +753,7 @@ export class VerdocsSign {
         // @ts-expect-error - v6.9.13
         const result = await envelopeRecipientSubmit(this.endpoint, this.envelopeId, this.roleId, {locale: localeData.locale, timezone: localeData.timeZone});
         console.log('[SIGN] Submitted successfully', result);
-        // TODO: The "proper" way is generating an error from Stencil
-        //  NotFoundError: Failed to execute 'insertBefore' on 'Node': The node before which
-        //  the new node is to be inserted is not a child of this node.
-        window.location.reload();
+        await this.handleSubmitSuccess();
       } catch (e) {
         console.log('[SIGN] Error submitting', e);
         this.submitting = false;
@@ -745,6 +806,10 @@ export class VerdocsSign {
 
   // See if everything that "needs to be" filled in is, and all "fillable fields" are valid
   checkRecipientFields() {
+    if (this.submitted || this.isDone) {
+      return;
+    }
+
     const invalidFields = this.getRecipientFields().filter(field => !isFieldValid(field, this.getRecipientFields()));
     if (invalidFields.length < 1) {
       this.nextButtonLabel = 'Finish';
@@ -1142,7 +1207,7 @@ export class VerdocsSign {
             message={`Sorry, your invite code is invalid or has expired. Please check your email for an updated invitation, or contact the sender.`}
             buttonLabel="OK"
             onNext={() => {
-              window.location.reload();
+              this.retrySigningSession();
             }}
           />
         </Host>
@@ -1195,8 +1260,7 @@ export class VerdocsSign {
               onNext={(e: any) => {
                 e.preventDefault();
                 e.stopPropagation();
-                this.showDone = false;
-                this.isDone = true;
+                this.handleDoneDialogDismiss();
               }}
             />
           )}
@@ -1264,7 +1328,9 @@ export class VerdocsSign {
               envelopeRecipientDecline(this.endpoint, this.envelopeId, this.roleId)
                 .then(r => {
                   console.log('[SIGN] Decline result', r);
-                  window.location.reload();
+                  this.declining = false;
+                  this.fatalErrorHeader = 'Declined';
+                  this.fatalErrorMessage = 'You have declined to sign this request. The sender has been notified.';
                 })
                 .catch(e => {
                   console.warn('[SIGN] Error declining signing session', e);
@@ -1445,7 +1511,7 @@ export class VerdocsSign {
               <div class="title">{this.envelope.name}</div>
               <div style={{flex: '1'}} />
 
-              {!this.finishLater &&
+              {!this.finishLater && !this.submitted &&
                 (() => {
                   const remaining = this.getRequiredTotalCount() - this.getRequiredFilledCount();
                   const optionalLeft = this.getOptionalUnfilledCount();
@@ -1470,11 +1536,11 @@ export class VerdocsSign {
                   );
                 })()}
 
-              {!this.finishLater && (
+              {!this.finishLater && !this.submitted && (
                 <verdocs-button
                   size="xsmall"
                   label={this.nextButtonLabel === 'Next' ? 'Next Required' : this.nextButtonLabel}
-                  disabled={!this.agreed || this.submitting}
+                  disabled={!this.agreed || this.submitting || this.submitted}
                   onClick={() => this.handleNext()}
                 />
               )}
@@ -1490,7 +1556,7 @@ export class VerdocsSign {
                 onClick={() => this.handleZoomIn()}
               />
 
-              <verdocs-dropdown options={!this.isDone && !this.finishLater ? inProgressMenuOptions : doneMenuOptions} onOptionSelected={e => this.handleOptionSelected(e)} />
+              <verdocs-dropdown options={!this.isDone && !this.finishLater && !this.submitted ? inProgressMenuOptions : doneMenuOptions} onOptionSelected={e => this.handleOptionSelected(e)} />
             </div>
           </div>
         )}
@@ -1508,7 +1574,9 @@ export class VerdocsSign {
               <span class="count">of {totalPages}</span>
             </div>
             <div class="right-controls">
-              <verdocs-button class="mobile-next-button" label={this.nextButtonLabel} size="xsmall" disabled={!this.agreed || this.submitting} onClick={() => this.handleNext()} />
+              {!this.submitted && (
+                <verdocs-button class="mobile-next-button" label={this.nextButtonLabel} size="xsmall" disabled={!this.agreed || this.submitting} onClick={() => this.handleNext()} />
+              )}
               <div class={{'icon-button': true, 'minus': true, 'disabled': this.zoomLevel === 'normal'}} innerHTML={ToolbarMinusIcon} onClick={() => this.handleZoomOut()} />
               <div class={{'icon-button': true, 'plus': true, 'disabled': this.zoomLevel === 'zoom2'}} innerHTML={ToolbarPlusIcon} onClick={() => this.handleZoomIn()} />
               <div class="icon-button download" innerHTML={ToolbarDownloadIcon} onClick={() => this.handleOptionSelected({detail: {id: 'download'}})} />
@@ -1593,8 +1661,7 @@ export class VerdocsSign {
             heading="You're Done!"
             message={`You can access the ${this.documentsSingularPlural} at any time by clicking on the link from the invitation email.<br /><br />After all recipients have completed their actions, you will receive an email with the document and envelope certificate attached.`}
             onNext={() => {
-              this.showDone = false;
-              this.isDone = true;
+              this.handleDoneDialogDismiss();
             }}
           />
         )}
@@ -1673,7 +1740,7 @@ export class VerdocsSign {
           />
         )}
 
-        {!this.loading && !this.isDone && (
+        {!this.loading && !this.isDone && !this.submitted && (
           <verdocs-sign-footer
             endpoint={this.endpoint}
             envelopeId={this.envelopeId}


### PR DESCRIPTION
## Description
* Replaced the `window.location.reload()` logic in `verdocs-sign` with the component-only re-render logic.
* Added unit tests for `verdocs-sign`.

## Demo
https://jam.dev/c/1e380507-6801-466d-9f36-ac899f2c2631